### PR TITLE
Adding references to the new NMEA2000_teensy in the READMEs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,6 +28,9 @@ CAN_BUS shield card. Under documents there is file ArduinoMega_CAN_with_MCP2515_
 for layout to build CAN-bus interface by yourself. MCP2515, MCP2551, ocillator and few
 components cost only few euros, if you are handy and used to use soldering device.
 
+ - Teensy 3.1/3.2 board with a MCP2551 CAN transeiver (or similar, see FlexCAN documentation).
+The [NMEA2000_teensy](https://github.com/sarfata/NMEA2000_teensy) implements this driver.
+
 Library has been also used with Maple Mini board, which is much cheaper than Arduino. mcp_can
 possibly works also with other Arduinos, but has not yet been tested.
 

--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ and mcp_can library. mcp_can library can be originally found on https://github.c
 Currently NMEA2000_mcp library uses developed version, which allows also to use 8MHz clock and
 has been tested with Maple Mini. So until these improvements has not been implemented to Seeed-Studio
 library, use library found on https://github.com/peppeve/CAN_BUS_Shield
+
+To use a Teensy 3.1/3.2 board with a MCP2551 CAN transeiver, you will need the [NMEA2000_teensy](https://github.com/sarfata/NMEA2000_teensy) contributed by [Thomas Sarlandie](https://twitter.com/sarfata/) and the [FlexCAN library](https://github.com/teachop/FlexCAN_Library).


### PR DESCRIPTION
Thanks @ttlappalainen for this amazing NMEA2000 library. It seems to work very well with a Teensy board.

I have it connected to a NMEA2000 network with a Raymarine i70 and an Airmar DST800. Communication works from the devices to the board and from the board to the i70.

I have noticed that there seemed to be a problem in the conversion of doubles (the speed displayed on the i70 seems to be double the speed I set in the code). I am not sure if that is teensy specific or not. Will continue to look into this.