### PR TITLE
BatteryMonitor example memory,  added URL for NMEA2000_avr

### DIFF
--- a/Examples/BatteryMonitor/BatteryMonitor.ino
+++ b/Examples/BatteryMonitor/BatteryMonitor.ino
@@ -1,33 +1,58 @@
-// Demo: NMEA2000 library. Send main cabin temperature to the bus.
+// Demo: NMEA2000 library. Send battery status to the bus.
+//
+//
+//      In this example are shown ways to minimize the size and RAM usage using two techniques:
+//        1) Moving data strictures to PROGMEM vs. using inline constantans when calling a function
+//        2) Reducing the number of NMEA CAN buffers to the min needed.  Use caution with this, as some functions
+//           (specifically fastMessages) require more buffers. 
+//
+
 
 #include <Arduino.h>
 //#define N2k_CAN_INT_PIN 21
-#include <NMEA2000_CAN.h>  // This will automatically choose right CAN library and create suitable NMEA2000 object
+#include <NMEA2000_CAN.h>       // This will automatically choose right CAN library and create suitable NMEA2000 object
 #include <N2kMessages.h>
 
+
+
+const tProductInformation BatteryMonitorProductInformation PROGMEM={
+                                       1300,                        // N2kVersion
+                                       100,                         // Manufacturer's product code
+                                       "Simple battery monitor",    // Manufacturer's Model ID
+                                       "1.0.0.12 (2016-02-02)",     // Manufacturer's Software version code
+                                       "1.0.0.0 (2015-08-03)"       // Manufacturer's Model version
+                                       "00000001",                  // Manufacturer's Model serial code
+                                       0,                            // SertificationLevel
+                                       1                             // LoadEquivalency
+                                      };                                      
+
+                                      // ---  Example of using PROGMEM to hold Product ID.  However, doing this will prevent any updating of
+                                      //      these details outside of recompiling the program.
+                                      
+                                      
 void setup() {
   // Set Product information
-  NMEA2000.SetProductInformation("00000001", // Manufacturer's Model serial code
-                                 100, // Manufacturer's product code
-                                 "Simple battery monitor",  // Manufacturer's Model ID
-                                 "1.0.0.12 (2016-02-02)",  // Manufacturer's Software version code
-                                 "1.0.0.0 (2015-08-03)" // Manufacturer's Model version
-                                 );
-  // Det device information
-  NMEA2000.SetDeviceInformation(1, // Unique number. Use e.g. Serial number.
-                                170, // Device function=Battery. See codes on http://www.nmea.org/Assets/20120726%20nmea%202000%20class%20&%20function%20codes%20v%202.00.pdf
-                                35, // Device class=Electrical Generation. See codes on  http://www.nmea.org/Assets/20120726%20nmea%202000%20class%20&%20function%20codes%20v%202.00.pdf
-                                2046 // Just choosen free from code list on http://www.nmea.org/Assets/20121020%20nmea%202000%20registration%20list.pdf                               
+  NMEA2000.SetProductInformation(&BatteryMonitorProductInformation );
+      
+  // Set device information
+  NMEA2000.SetDeviceInformation(1,      // Unique number. Use e.g. Serial number.
+                                170,    // Device function=Battery. See codes on http://www.nmea.org/Assets/20120726%20nmea%202000%20class%20&%20function%20codes%20v%202.00.pdf
+                                35,     // Device class=Electrical Generation. See codes on  http://www.nmea.org/Assets/20120726%20nmea%202000%20class%20&%20function%20codes%20v%202.00.pdf
+                                2046    // Just choosen free from code list on http://www.nmea.org/Assets/20121020%20nmea%202000%20registration%20list.pdf                               
                                );
+                               
+                               
   // Uncomment 3 rows below to see, what device will send to bus                           
    Serial.begin(115200);
-  // NMEA2000.SetForwardType(tNMEA2000::fwdt_Text); // Show in clear text. Leave uncommented for default Actisense format.
+  // NMEA2000.SetForwardType(tNMEA2000::fwdt_Text);     // Show in clear text. Leave uncommented for default Actisense format.
   NMEA2000.SetForwardOwnMessages();
 
   // If you also want to see all traffic on the bus use N2km_ListenAndNode instead of N2km_NodeOnly below
   NMEA2000.SetMode(tNMEA2000::N2km_NodeOnly,22);
-  //NMEA2000.SetDebugMode(tNMEA2000::dm_ClearText); // Uncomment this, so you can test code without CAN bus chips on Arduino Mega
-  //NMEA2000.EnableForward(false); // Disable all msg forwarding to USB (=Serial)
+  //NMEA2000.SetDebugMode(tNMEA2000::dm_ClearText);     // Uncomment this, so you can test code without CAN bus chips on Arduino Mega
+  //NMEA2000.EnableForward(false);                      // Disable all msg forwarding to USB (=Serial)
+  
+  NMEA2000.SetN2kCANMsgBufSize(2);                      // For this simple example, restrict to only 2 NMEA buffers, one send, one receive.
   NMEA2000.Open();
 }
 

--- a/N2kMsg.cpp
+++ b/N2kMsg.cpp
@@ -511,16 +511,16 @@ void PrintBuf(Stream *port, unsigned char len, const unsigned char *pData) {
 //*****************************************************************************
 void tN2kMsg::Print(Stream *port, bool NoData) const {
   if (!IsValid()) return;
-  port->print("Pri:"); port->print(Priority);
-  port->print(" PGN:"); port->print(PGN);
-  port->print(" Source:"); port->print(Source);
-  port->print(" Dest:"); port->print(Destination);
-  port->print(" Len:"); port->print(DataLen);
+  port->print(F("Pri:")); port->print(Priority);
+  port->print(F(" PGN:")); port->print(PGN);
+  port->print(F(" Source:")); port->print(Source);
+  port->print(F(" Dest:")); port->print(Destination);
+  port->print(F(" Len:")); port->print(DataLen);
   if (!NoData) {
-    port->print(" Data:");
+    port->print(F(" Data:"));
     PrintBuf(port,DataLen,Data);
   }
-  port->print("\r\n");
+  port->print(F("\r\n"));
 }
 
 //*****************************************************************************

--- a/NMEA2000_CAN.h
+++ b/NMEA2000_CAN.h
@@ -68,7 +68,7 @@ tNMEA2000_teensy NMEA2000;
 #elif USE_N2K_CAN == USE_N2K_AVR_CAN
 // Use Atmel AVR internal CAN controller with avr_can library
 #include <avr_can.h>            // https://github.com/thomasonw/avr_can
-#include <NMEA2000_avr.h> 
+#include <NMEA2000_avr.h>       // https://github.com/thomasonw/NMEA2000_avr
 tNMEA2000_avr NMEA2000;
 
 #else  // Use USE_N2K_MCP_CAN


### PR DESCRIPTION
Modified BatteryMonitoro.ino to show what is the basic minimum for a functional small NMEA-2000 reporting only device.  

Added URL for NMEA2000_avr