### PR TITLE
Correct Battery Current in ParseN2kPGN127508

### DIFF
--- a/N2kMessages.cpp
+++ b/N2kMessages.cpp
@@ -333,7 +333,7 @@ bool ParseN2kPGN127508(const tN2kMsg &N2kMsg, unsigned char &BatteryInstance, do
   int Index=0;
   BatteryInstance=N2kMsg.GetByte(Index);
   BatteryVoltage=N2kMsg.Get2ByteDouble(0.01,Index);
-  BatteryCurrent=N2kMsg.Get2ByteDouble(0.01,Index);
+  BatteryCurrent=N2kMsg.Get2ByteDouble(0.1,Index);
   BatteryTemperature=N2kMsg.Get2ByteUDouble(0.01,Index);
   SID=N2kMsg.GetByte(Index);
 

--- a/N2kMessages.h
+++ b/N2kMessages.h
@@ -517,11 +517,11 @@ inline void SetN2kDCBatStatus(tN2kMsg &N2kMsg, unsigned char BatteryInstance, do
   SetN2kPGN127508(N2kMsg,BatteryInstance,BatteryVoltage,BatteryCurrent,BatteryTemperature,SID);
 }
 
-bool ParseN2kPGN130312(const tN2kMsg &N2kMsg, unsigned char &BatteryInstance, double &BatteryVoltage, double &BatteryCurrent,
+bool ParseN2kPGN127508(const tN2kMsg &N2kMsg, unsigned char &BatteryInstance, double &BatteryVoltage, double &BatteryCurrent,
                      double &BatteryTemperature, unsigned char &SID);
 inline bool ParseN2kDCBatStatus(const tN2kMsg &N2kMsg, unsigned char &BatteryInstance, double &BatteryVoltage, double &BatteryCurrent,
                      double &BatteryTemperature, unsigned char &SID) {
-  return ParseN2kPGN130312(N2kMsg, BatteryInstance, BatteryVoltage, BatteryCurrent, BatteryTemperature, SID);
+  return ParseN2kPGN127508(N2kMsg, BatteryInstance, BatteryVoltage, BatteryCurrent, BatteryTemperature, SID);
 }
 
 


### PR DESCRIPTION
Battery Current in the CAN packet are in 100mA steps.  Changes scalar to 0.1 from 0.01 to reflect this.