### PR TITLE
 	Added to API -- Optional message lists

### DIFF
--- a/NMEA2000.cpp
+++ b/NMEA2000.cpp
@@ -69,20 +69,24 @@ void ClearSetCharBuf(const char *str, int MaxLen, char *buf) {
   if (str) SetCharBuf(str,MaxLen,buf);
 }
 
-//*****************************************************************************
-void SetMsgBuf(const unsigned long *msgs, int MaxLen, unsigned long* buf) {
-  for (int i=0; i<MaxLen-1 && msgs[i]!=0; i++) buf[i]=msgs[i];
-  buf[MaxLen]=0;
-}
  
 //*****************************************************************************
+void tNMEA2000::SetSingleFrameMessages(const unsigned long *_SingleFrameMessages) {
+  SingleFrameMessages=_SingleFrameMessages;
+  if (SingleFrameMessages==0) SingleFrameMessages=DefSingleFrameMessages;
+}
+
+//*****************************************************************************
+void tNMEA2000::SetFastPacketMessages(const unsigned long *_FastPacketMessages) {
+  FastPacketMessages=_FastPacketMessages;
+  if (FastPacketMessages==0) FastPacketMessages=DefFastPacketMessages;
+}
+
+//*****************************************************************************
 tNMEA2000::tNMEA2000() {
-  // Point for message code buffers was that developer can dynamically change them.
-  // Currentrly there has not been any need for that, so due to ram optmization do it later.
+
   SingleFrameMessages=DefSingleFrameMessages;
   FastPacketMessages=DefFastPacketMessages;
-  //SetMsgBuf(DefSingleFrameMessages,Max_N2kSingleFrameMessages_len,SingleFrameMessages);
-  //SetMsgBuf(DefFastPacketMessages,Max_N2kFastPacketMessages_len,FastPacketMessages);
   
   N2kCANMsgBuf=0;
   MaxN2kCANMsgs=0;

--- a/NMEA2000.h
+++ b/NMEA2000.h
@@ -220,7 +220,11 @@ public:
     // Note that I have not yet found a way to test is pointer in PROGMEM or not, so this does not work, if you define
     // tProductInformation to RAM.
     void SetProductInformation(const tProductInformation *_ProductInformation);  
-
+    
+    // Call these if you wish to modify the default message packets supported.  Pointers must be in PROGMEM
+    void SetSingleFrameMessages(const unsigned long *_SingleFrameMessages);
+    void SetFastPacketMessages (const unsigned long *_FastPacketMessages);
+ 
     // Set default device information.
     // For keeping defaults use 0xffff/0xff for int/char values and nul ptr for pointers.
     // Note that ManufacturerCode and UniqueNumber should give unic result on any network.


### PR DESCRIPTION
Added two APIs to allow setting of SingleFrameMessages and
FastPacketMessages arrays.  Allows for extension (and editing) of
supported messages.