### PR TITLE
Re-send ISO Address claim if request came from 0xff

### DIFF
--- a/NMEA2000.cpp
+++ b/NMEA2000.cpp
@@ -504,6 +504,12 @@ void tNMEA2000::ForwardMessage(const tN2kCANMsg &N2kCanMsg) {
 
 //*****************************************************************************
 void tNMEA2000::SendIsoAddressClaim(unsigned char Destination, int DeviceIndex) {
+  
+  // Some devices (Garmin) request constantly information on network about others
+  // 59904 ISO Request:  PGN = 60928
+  // So we need to Re-send Address claim, or they will stop detecting us
+  if (Destination==0xff && DeviceIndex==-1) DeviceIndex=0;
+  
   if ( DeviceIndex<0 || DeviceIndex>=DeviceCount) return;
   tN2kMsg RespondMsg(N2kSource[DeviceIndex]);
 


### PR DESCRIPTION
Some devices (Garmin GNX 20) request constantly information on network about others
Ex: 59904 ISO Request:  PGN = 60928
So we need to Re-send Address claim, or they will stop detecting (seeing) us

Here is an example of such communication:

```
2016-08-18T19:26:19.844Z 6   2 255  59904 ISO Request:  PGN = 60928
2016-08-18T19:26:19.844Z 6  22 255  60928 ISO Address Claim:  Unique Number = 0x1; Manufacturer Code = ERROR; Device Instance Lower = 0; Device Instance Upper = 0; Device Function = 130; Device Class = Internetwork device; System Instance = 0; Industry Group = Marine
2016-08-18T19:26:19.844Z 6   1 255  60928 ISO Address Claim:  Unique Number = 0x1c0640; Manufacturer Code = Garmin; Device Instance Lower = 0; Device Instance Upper = 0; Device Function = 130; Device Class = Display; System Instance = 0; Industry Group = Marine
2016-08-18T19:26:24.843Z 6   2 255  59904 ISO Request:  PGN = 60928
2016-08-18T19:26:24.843Z 6  22 255  60928 ISO Address Claim:  Unique Number = 0x1; Manufacturer Code = ERROR; Device Instance Lower = 0; Device Instance Upper = 0; Device Function = 130; Device Class = Internetwork device; System Instance = 0; Industry Group = Marine
2016-08-18T19:26:24.843Z 6   1 255  60928 ISO Address Claim:  Unique Number = 0x1c0640; Manufacturer Code = Garmin; Device Instance Lower = 0; Device Instance Upper = 0; Device Function = 130; Device Class = Display; System Instance = 0; Industry Group = Marine
2016-08-18T19:26:29.827Z 6   2 255  59904 ISO Request:  PGN = 60928
2016-08-18T19:26:29.828Z 6  22 255  60928 ISO Address Claim:  Unique Number = 0x1; Manufacturer Code = ERROR; Device Instance Lower = 0; Device Instance Upper = 0; Device Function = 130; Device Class = Internetwork device; System Instance = 0; Industry Group = Marine
2016-08-18T19:26:29.843Z 6   1 255  60928 ISO Address Claim:  Unique Number = 0x1c0640; Manufacturer Code = Garmin; Device Instance Lower = 0; Device Instance Upper = 0; Device Function = 130; Device Class = Display; System Instance = 0; Industry Group = Marine
2016-08-18T19:26:34.844Z 6   2 255  59904 ISO Request:  PGN = 60928
2016-08-18T19:26:34.844Z 6  22 255  60928 ISO Address Claim:  Unique Number = 0x1; Manufacturer Code = ERROR; Device Instance Lower = 0; Device Instance Upper = 0; Device Function = 130; Device Class = Internetwork device; System Instance = 0; Industry Group = Marine
2016-08-18T19:26:34.844Z 6   1 255  60928 ISO Address Claim:  Unique Number = 0x1c0640; Manufacturer Code = Garmin; Device Instance Lower = 0; Device Instance Upper = 0; Device Function = 130; Device Class = Display; System Instance = 0; Industry Group = Marine
2016-08-18T19:28:23.315Z 6   1 255  59904 ISO Request:  PGN = 60928
2016-08-18T19:28:23.315Z 6  22 255  60928 ISO Address Claim:  Unique Number = 0x1; Manufacturer Code = ERROR; Device Instance Lower = 0; Device Instance Upper = 0; Device Function = 130; Device Class = Internetwork device; System Instance = 0; Industry Group = Marine
2016-08-18T19:28:23.315Z 6   2 255  60928 ISO Address Claim:  Unique Number = 0x1fa20e; Manufacturer Code = Garmin; Device Instance Lower = 0; Device Instance Upper = 0; Device Function = 130; Device Class = Display; System Instance = 0; Industry Group = Marine
```
In the log, we have 3 devices:
- Device 1 - GNX 20 Display
- Device 2 - GNX Wind display
- Device 3 - Teensy 3.2 with patched NMEA 2000 library