### PR TITLE
Frame setter bugfix

### DIFF
--- a/NMEA2000.cpp
+++ b/NMEA2000.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
 NMEA2000.cpp
 
 2015-2016 Copyright (c) Kave Oy, www.kave.fi  All right reserved.
@@ -21,7 +21,7 @@ Author: Timo Lappalainen
   1301  USA
 */
 
-#include <NMEA2000.h> 
+#include <NMEA2000.h>
 
 #define N2kAddressClaimTimeout 250
 
@@ -32,7 +32,7 @@ Author: Timo Lappalainen
 
 const unsigned long SingleFrameSystemMessages[] PROGMEM={59392L /*ISO Acknowledgement*/, 59904L /*ISO Request*/, 60928L /*ISO Address Claim*/,
                                        0};
-const unsigned long FastPacketSystemMessages[] PROGMEM={126208L, 
+const unsigned long FastPacketSystemMessages[] PROGMEM={126208L,
                                        0};
 const unsigned long DefSingleFrameMessages[] PROGMEM={
                                        126992L, // System date/time
@@ -82,21 +82,21 @@ const tProductInformation DefProductInformation PROGMEM={
                                        "00000001", // N2kModelSerialCode
                                        0, // SertificationLevel
                                        1 // LoadEquivalency
-                                      };       
+                                      };
 
 const tNMEA2000::tProgmemConfigurationInformation DefConfigurationInformation PROGMEM={
                                        "NMEA2000 library, https://github.com/ttlappalainen/NMEA2000", // Manufacturer information
                                        "", // Installation description1
                                        "" // Installation description2
                                       };
-                                      
+
 //*****************************************************************************
 void ClearCharBuf(int MaxLen, char *buf) {
   if ( buf==0 ) return;
   int i=0;
   for (; i<MaxLen; i++) buf[i]=0;
 }
- 
+
 //*****************************************************************************
 void SetCharBuf(const char *str, int MaxLen, char *buf) {
   if ( str==0 || buf==0 || MaxLen<=0 ) return;
@@ -105,7 +105,7 @@ void SetCharBuf(const char *str, int MaxLen, char *buf) {
   for (; i<MaxLen; i++) buf[i]=0;
   buf[MaxLen-1]=0; // Force null ternimation
 }
- 
+
 //*****************************************************************************
 void ClearSetCharBuf(const char *str, int MaxLen, char *buf) {
   ClearCharBuf(MaxLen,buf);
@@ -118,16 +118,16 @@ tNMEA2000::tNMEA2000() {
   SingleFrameMessages[0]=DefSingleFrameMessages;
   FastPacketMessages[0]=DefFastPacketMessages;
   for (int i=1; i<N2kMessageGroups; i++) {SingleFrameMessages[i]=0; FastPacketMessages[i]=0;}
-  
+
   N2kCANMsgBuf=0;
   MaxN2kCANMsgs=0;
-  
+
   MaxCANSendFrames=40;
   CANSendFrameBuf=0;
-  
+
   MsgHandler=0;
   ISORqstHandler=0;
-  
+
   ForwardStream=&Serial;
   DeviceInformation[0].N2kSource=0;
   DeviceReady=false;
@@ -174,11 +174,11 @@ void tNMEA2000::SetProductInformation(const tProductInformation *_ProductInforma
 //*****************************************************************************
 void tNMEA2000::SetProductInformation(const char *_ModelSerialCode,
                                       unsigned int _ProductCode,
-                                      const char *_ModelID, 
-                                      const char *_SwCode, 
+                                      const char *_ModelID,
+                                      const char *_SwCode,
                                       const char *_ModelVersion,
                                       unsigned char _LoadEquivalency,
-                                      unsigned int _N2kVersion, 
+                                      unsigned int _N2kVersion,
                                       unsigned char _SertificationLevel) {
    if (LocalProductInformation==0) {
      LocalProductInformation=new tProductInformation();
@@ -186,10 +186,10 @@ void tNMEA2000::SetProductInformation(const char *_ModelSerialCode,
    ProductInformation=LocalProductInformation;
    LocalProductInformation->N2kVersion=(_N2kVersion!=0xffff?_N2kVersion:1300);
    LocalProductInformation->ProductCode=_ProductCode;
-   ClearSetCharBuf(_ModelID,sizeof(LocalProductInformation->N2kModelID),LocalProductInformation->N2kModelID); 
-   ClearSetCharBuf(_SwCode,sizeof(LocalProductInformation->N2kSwCode),LocalProductInformation->N2kSwCode); 
-   ClearSetCharBuf(_ModelVersion,sizeof(LocalProductInformation->N2kModelVersion),LocalProductInformation->N2kModelVersion); 
-   ClearSetCharBuf(_ModelSerialCode,sizeof(LocalProductInformation->N2kModelSerialCode),LocalProductInformation->N2kModelSerialCode); 
+   ClearSetCharBuf(_ModelID,sizeof(LocalProductInformation->N2kModelID),LocalProductInformation->N2kModelID);
+   ClearSetCharBuf(_SwCode,sizeof(LocalProductInformation->N2kSwCode),LocalProductInformation->N2kSwCode);
+   ClearSetCharBuf(_ModelVersion,sizeof(LocalProductInformation->N2kModelVersion),LocalProductInformation->N2kModelVersion);
+   ClearSetCharBuf(_ModelSerialCode,sizeof(LocalProductInformation->N2kModelSerialCode),LocalProductInformation->N2kModelSerialCode);
    LocalProductInformation->SertificationLevel=(_SertificationLevel!=0xff?_SertificationLevel:1);
    LocalProductInformation->LoadEquivalency=(_LoadEquivalency!=0xff?_LoadEquivalency:1);
 }
@@ -213,15 +213,15 @@ void tNMEA2000::SetConfigurationInformation(const char *ManufacturerInformation,
 
     int TotalSize=SizeCI+ManInfoLen+InstDesc1Len+InstDesc2Len;
     void *mem=malloc(TotalSize);
-    
+
     LocalConfigurationInformation=(tConfigurationInformation*)mem;
     LocalConfigurationInformation->ManufacturerInformation=(ManInfoLen?(char *)(((uint8_t*)mem)+SizeCI):0);
     LocalConfigurationInformation->InstallationDescription1=(InstDesc1Len?(char *)(((uint8_t*)mem)+SizeCI+ManInfoLen):0);
     LocalConfigurationInformation->InstallationDescription2=(InstDesc2Len?(char *)(((uint8_t*)mem)+SizeCI+ManInfoLen+InstDesc1Len):0);
 
-    SetCharBuf(ManufacturerInformation,ManInfoLen,LocalConfigurationInformation->ManufacturerInformation); 
-    SetCharBuf(InstallationDescription1,InstDesc1Len,LocalConfigurationInformation->InstallationDescription1); 
-    SetCharBuf(InstallationDescription2,InstDesc2Len,LocalConfigurationInformation->InstallationDescription2); 
+    SetCharBuf(ManufacturerInformation,ManInfoLen,LocalConfigurationInformation->ManufacturerInformation);
+    SetCharBuf(InstallationDescription1,InstDesc1Len,LocalConfigurationInformation->InstallationDescription1);
+    SetCharBuf(InstallationDescription2,InstDesc2Len,LocalConfigurationInformation->InstallationDescription2);
   }
 
 }
@@ -248,13 +248,13 @@ void tNMEA2000::SetDeviceInformation(unsigned long _UniqueNumber,
 //*****************************************************************************
 void tNMEA2000::SetSingleFrameMessages(const unsigned long *_SingleFrameMessages) {
   SingleFrameMessages[0]=_SingleFrameMessages;
-  if (SingleFrameMessages==0) SingleFrameMessages[0]=DefSingleFrameMessages;
+  if (SingleFrameMessages[0]==0) SingleFrameMessages[0]=DefSingleFrameMessages;
 }
 
 //*****************************************************************************
 void tNMEA2000::SetFastPacketMessages(const unsigned long *_FastPacketMessages) {
   FastPacketMessages[0]=_FastPacketMessages;
-  if (FastPacketMessages==0) FastPacketMessages[0]=DefFastPacketMessages;
+  if (FastPacketMessages[0]==0) FastPacketMessages[0]=DefFastPacketMessages;
 }
 
 //*****************************************************************************
@@ -282,15 +282,15 @@ bool tNMEA2000::Open() {
       N2kCANMsgBuf = new tN2kCANMsg[MaxN2kCANMsgs];
       for (int i=0; i<MaxN2kCANMsgs; i++) N2kCANMsgBuf[i].FreeMessage();
     }
-    
+
     if ( CANSendFrameBuf==0 ) {
       CANSendFrameBuf = new tCANSendFrame[MaxCANSendFrames];
       CANSendFrameBufferWrite=0;
       CANSendFrameBufferRead=0;
     }
-  
+
     DeviceReady=CANOpen();
-    if ( (ForwardStream!=0) && (ForwardType==tNMEA2000::fwdt_Text) ) { 
+    if ( (ForwardStream!=0) && (ForwardType==tNMEA2000::fwdt_Text) ) {
       if ( DeviceReady ) { ForwardStream->println(F("CAN device ready")); } else { ForwardStream->println(F("CAN device failed to open")); }
     }
 
@@ -301,8 +301,8 @@ bool tNMEA2000::Open() {
       SendIsoAddressClaim(0xff,0);
       AddressClaimStarted=millis();
     }
-  } 
-  
+  }
+
   return DeviceReady;
 }
 
@@ -347,13 +347,13 @@ bool tNMEA2000::SendFrames()
       CANSendFrameBufferRead=temp;
     } else return false;
   }
-  
+
   return true;
 }
 
 //*****************************************************************************
 bool tNMEA2000::SendFrame(unsigned long id, unsigned char len, const unsigned char *buf, bool wait_sent) {
-  
+
   if ( !SendFrames() || !CANSendFrame(id,len,buf,wait_sent) ) { // If we can not sent frame immediately, add it to buffer
     tCANSendFrame *Frame=GetNextFreeCANSendFrame();
     if ( Frame==0 ) return false;
@@ -362,16 +362,16 @@ bool tNMEA2000::SendFrame(unsigned long id, unsigned char len, const unsigned ch
     Frame->wait_sent=wait_sent;
     for (int i=0; i<len && i<8; i++) Frame->buf[i]=buf[i];
   }
-  
+
   return true;
 }
 
 //*****************************************************************************
-tNMEA2000::tCANSendFrame *tNMEA2000::GetNextFreeCANSendFrame() { 
+tNMEA2000::tCANSendFrame *tNMEA2000::GetNextFreeCANSendFrame() {
   if (CANSendFrameBuf==0) return 0;
 
   uint8_t temp = (CANSendFrameBufferWrite + 1) % MaxCANSendFrames;
-  
+
   if (temp != CANSendFrameBufferRead) {
     CANSendFrameBufferWrite = temp;
     return &(CANSendFrameBuf[CANSendFrameBufferWrite]);
@@ -390,24 +390,24 @@ void tNMEA2000::SendPendingInformation() {
 
 //*****************************************************************************
 // Sends message to N2k bus
-// 
+//
 bool tNMEA2000::SendMsg(const tN2kMsg &N2kMsg, int DeviceIndex) {
 //void tNMEA2000::SendMsg(unsigned long priority, unsigned long PGN, unsigned long Source, unsigned long Destination, INT8U len, const INT8U *pData) {
   static int SendOrder=0;
   bool result=false;
-  
+
   if ( DeviceIndex>=DeviceCount) return result;
   N2kMsg.CheckDestination();
   if (DeviceIndex>=0) N2kMsg.ForceSource(DeviceInformation[DeviceIndex].N2kSource);
-  
+
   if (N2kMsg.Source>253) return false; // CAN bus address range is 0-253.
-  
+
   unsigned long canId=N2ktoCanID(N2kMsg.Priority,N2kMsg.PGN,N2kMsg.Source, N2kMsg.Destination);
 
   if (N2kMode==N2km_ListenOnly) return false; // Do not send anything on listen only mode
-  
+
   if (N2kMsg.PGN==0) return false;
-  
+
   switch (dbMode) {
     case dm_None:
 //      ForwardStream->print("Send PGN:"); ForwardStream->println(N2kMsg.PGN);
@@ -418,7 +418,7 @@ bool tNMEA2000::SendMsg(const tN2kMsg &N2kMsg, int DeviceIndex) {
 
       if (N2kMsg.DataLen<=8) { // We can send single frame
 //          PrintBuf(ForwardStream,N2kMsg.DataLen, N2kMsg.Data,true);
-          result=SendFrame(canId, N2kMsg.DataLen, N2kMsg.Data,false); 
+          result=SendFrame(canId, N2kMsg.DataLen, N2kMsg.Data,false);
           if (!result && ForwardStream!=0 && ForwardType==tNMEA2000::fwdt_Text) { ForwardStream->print(F("PGN ")); ForwardStream->print(N2kMsg.PGN); ForwardStream->println(F(" send failed")); }
       } else { // Send it as fast packet in multiple frames
         unsigned char temp[8]; // {0,0,0,0,0,0,0,0};
@@ -431,28 +431,28 @@ bool tNMEA2000::SendMsg(const tN2kMsg &N2kMsg, int DeviceIndex) {
             if (i==0) {
                 temp[1] = N2kMsg.DataLen; //total bytes in fast packet
                 //send the first 6 bytes
-                for (int j = 2; j<8; j++) { 
+                for (int j = 2; j<8; j++) {
                      temp[j]=N2kMsg.Data[cur];
-                     cur++;   
+                     cur++;
                  }
             } else {
                  int j=1;
                  //send the next 7 data bytes
-                 for (; j<8 && cur<N2kMsg.DataLen; j++) { 
+                 for (; j<8 && cur<N2kMsg.DataLen; j++) {
                      temp[j]=N2kMsg.Data[cur];
-                     cur++;   
+                     cur++;
                  }
-                 for (; j<8; j++) { 
+                 for (; j<8; j++) {
                      temp[j]=0;
                  }
             }
             // delay(3);
 //            PrintBuf(ForwardStream,8,temp,true);
             result=SendFrame(canId, 8, temp, true);
-            if (!result && ForwardStream!=0 && ForwardType==tNMEA2000::fwdt_Text) { 
-              ForwardStream->print(F("PGN ")); ForwardStream->print(N2kMsg.PGN); 
-              ForwardStream->print(", frame:"); ForwardStream->print(i); ForwardStream->print("/"); ForwardStream->print(frames); 
-              ForwardStream->println(F(" send failed")); 
+            if (!result && ForwardStream!=0 && ForwardType==tNMEA2000::fwdt_Text) {
+              ForwardStream->print(F("PGN ")); ForwardStream->print(N2kMsg.PGN);
+              ForwardStream->print(", frame:"); ForwardStream->print(i); ForwardStream->print("/"); ForwardStream->print(frames);
+              ForwardStream->println(F(" send failed"));
             }
         }
         SendOrder++; if (SendOrder>7) SendOrder=0;
@@ -468,7 +468,7 @@ bool tNMEA2000::SendMsg(const tN2kMsg &N2kMsg, int DeviceIndex) {
       N2kMsg.SendInActisenseFormat(ForwardStream);
       break;
   }
-  
+
   return result;
 }
 
@@ -483,18 +483,18 @@ bool tNMEA2000::CheckKnownMessage(unsigned long PGN, bool &SystemMessage, bool &
 //    return true;
     FastPacket=false;
     if ( PGN==0 ) { SystemMessage=false; return false; }  // Unknown
-    
+
     // First check system messages
     SystemMessage=true;
     for (i=0; pgm_read_dword(&SingleFrameSystemMessages[i])!=PGN && pgm_read_dword(&SingleFrameSystemMessages[i])!=0; i++);
     if (pgm_read_dword(&SingleFrameSystemMessages[i])==PGN) return true;
-    
+
     for (i=0; pgm_read_dword(&FastPacketSystemMessages[i])!=PGN && pgm_read_dword(&FastPacketSystemMessages[i])!=0; i++);
     if (pgm_read_dword(&FastPacketSystemMessages[i])==PGN) {
       FastPacket=true;
       return true;
     }
-    
+
     // It was not system message, so check other messages
     SystemMessage=false;
     for (unsigned char igroup=0; (igroup<N2kMessageGroups); igroup++)  {
@@ -502,7 +502,7 @@ bool tNMEA2000::CheckKnownMessage(unsigned long PGN, bool &SystemMessage, bool &
         for (i=0; pgm_read_dword(&SingleFrameMessages[igroup][i])!=PGN && pgm_read_dword(&SingleFrameMessages[igroup][i])!=0; i++);
         if (pgm_read_dword(&SingleFrameMessages[igroup][i])==PGN) return true;
       }
-      
+
       if (FastPacketMessages[igroup]!=0) {
         for (i=0; pgm_read_dword(&FastPacketMessages[igroup][i])!=PGN && pgm_read_dword(&FastPacketMessages[igroup][i])!=0; i++);
         if (pgm_read_dword(&FastPacketMessages[igroup][i])==PGN) {
@@ -545,12 +545,12 @@ int tNMEA2000::SetN2kCANBufMsg(unsigned long canId, unsigned char len, unsigned 
           N2kCANMsgBuf[i].N2kMsg.Data[N2kCANMsgBuf[i].CopiedLen]=buf[j];
         }
       } else { // Handle first frame
-        for (i=0, CurTime=OldestMsgTime=millis(), OldestIndex=MaxN2kCANMsgs; 
+        for (i=0, CurTime=OldestMsgTime=millis(), OldestIndex=MaxN2kCANMsgs;
              i<MaxN2kCANMsgs && !(N2kCANMsgBuf[i].FreeMsg || (N2kCANMsgBuf[i].N2kMsg.PGN==PGN && N2kCANMsgBuf[i].N2kMsg.Source==Source));
              i++) { // Find free message place
           if (N2kCANMsgBuf[i].N2kMsg.MsgTime<OldestMsgTime) {
             OldestIndex=i;
-            OldestMsgTime=N2kCANMsgBuf[i].N2kMsg.MsgTime;            
+            OldestMsgTime=N2kCANMsgBuf[i].N2kMsg.MsgTime;
           }
         }
         if ( i==MaxN2kCANMsgs && OldestMsgTime+Max_N2kMsgBuf_Time<CurTime) i=OldestIndex; // Use the old one, which has timed out
@@ -579,7 +579,7 @@ int tNMEA2000::SetN2kCANBufMsg(unsigned long canId, unsigned char len, unsigned 
       N2kCANMsgBuf[i].Ready=(N2kCANMsgBuf[i].CopiedLen>=N2kCANMsgBuf[i].N2kMsg.DataLen);
       result=(N2kCANMsgBuf[i].Ready?i:-1); // If packet is ready, return index to it
     }
-    
+
     return result;
 }
 
@@ -587,13 +587,13 @@ int tNMEA2000::SetN2kCANBufMsg(unsigned long canId, unsigned char len, unsigned 
  int tNMEA2000::FindSourceDeviceIndex(unsigned char Source) {
    int result=-1;
    int i;
-   
+
      for (i=0; i<DeviceCount && DeviceInformation[i].N2kSource!=Source; i++);
      if (i<DeviceCount) result=i;
-     
+
      return result;
  }
- 
+
 //*****************************************************************************
 bool tNMEA2000::IsMySource(unsigned char Source) {
     return (FindSourceDeviceIndex(Source)!=-1);
@@ -601,10 +601,10 @@ bool tNMEA2000::IsMySource(unsigned char Source) {
 
 //*****************************************************************************
 void tNMEA2000::ForwardMessage(const tN2kMsg &N2kMsg) {
-  if ( !ForwardEnabled() || ( !( ForwardOwnMessages() && IsMySource(N2kMsg.Source) ) && N2kMode==N2km_NodeOnly ) ) return; 
+  if ( !ForwardEnabled() || ( !( ForwardOwnMessages() && IsMySource(N2kMsg.Source) ) && N2kMode==N2km_NodeOnly ) ) return;
 
   switch (ForwardType) {
-    case fwdt_Actisense: 
+    case fwdt_Actisense:
       N2kMsg.SendInActisenseFormat(ForwardStream);
       break;
     case fwdt_Text:
@@ -620,12 +620,12 @@ void tNMEA2000::ForwardMessage(const tN2kCANMsg &N2kCanMsg) {
 
 //*****************************************************************************
 void tNMEA2000::SendIsoAddressClaim(unsigned char Destination, int DeviceIndex) {
-  
+
   // Some devices (Garmin) request constantly information on network about others
   // 59904 ISO Request:  PGN = 60928
   // So we need to Re-send Address claim, or they will stop detecting us
   if (Destination==0xff && DeviceIndex==-1) DeviceIndex=0;
-  
+
   if ( DeviceIndex<0 || DeviceIndex>=DeviceCount) return;
   tN2kMsg RespondMsg(DeviceInformation[DeviceIndex].N2kSource);
 
@@ -639,7 +639,7 @@ template <typename T> void PROGMEM_readAnything (const T * sce, T& dest)
   memcpy_P (&dest, sce, sizeof (T));
   }
 
-                     
+
 //*****************************************************************************
 void SetN2kPGN126996Progmem(tN2kMsg &N2kMsg, const tProductInformation *ProductInformation) {
   int i;
@@ -695,7 +695,7 @@ void SetN2kPGN126998Progmem(tN2kMsg &N2kMsg, const tNMEA2000::tProgmemConfigurat
   int ManInfoLen=ProgmemStrLen(ConfigurationInformation->ManufacturerInformation);
   int InstDesc1Len=ProgmemStrLen(ConfigurationInformation->InstallationDescription1);
   int InstDesc2Len=ProgmemStrLen(ConfigurationInformation->InstallationDescription2);
-  
+
     TotalLen=0;
     if (TotalLen+ManInfoLen>MaxLen) ManInfoLen=MaxLen-TotalLen;
     TotalLen+=ManInfoLen;
@@ -703,7 +703,7 @@ void SetN2kPGN126998Progmem(tN2kMsg &N2kMsg, const tNMEA2000::tProgmemConfigurat
     TotalLen+=InstDesc1Len;
     if (TotalLen+InstDesc2Len>MaxLen) InstDesc2Len=MaxLen-TotalLen;
     TotalLen+=InstDesc2Len;
-  
+
     N2kMsg.SetPGN(126998L);
     N2kMsg.Priority=6;
     // InstallationDescription1
@@ -740,7 +740,7 @@ bool tNMEA2000::SendConfigurationInformation(int DeviceIndex) {
 
 //*****************************************************************************
 void tNMEA2000::RespondISORequest(const tN2kMsg &N2kMsg, unsigned long RequestedPGN, int iDev) {
-    switch (RequestedPGN) { 
+    switch (RequestedPGN) {
       case 60928L: /*ISO Address Claim*/  // Someone is asking others to claim their addresses
         SendIsoAddressClaim(N2kMsg.Source,iDev);
         break;
@@ -763,7 +763,7 @@ void tNMEA2000::RespondISORequest(const tN2kMsg &N2kMsg, unsigned long Requested
        tN2kMsg   N2kMsgR;
         SetN2kPGNISOAcknowledgement(N2kMsgR,1,0xff,RequestedPGN);       // No user handler, or there was one and it retured FALSE.  Send NAK
         N2kMsgR.Destination  = N2kMsg.Source;                             // Direct the response to original requester.
-        SendMsg(N2kMsgR); 
+        SendMsg(N2kMsgR);
     }
 }
 
@@ -771,9 +771,9 @@ void tNMEA2000::RespondISORequest(const tN2kMsg &N2kMsg, unsigned long Requested
 void tNMEA2000::HandleISORequest(const tN2kMsg &N2kMsg) {
   unsigned long RequestedPGN;
   int iDev=FindSourceDeviceIndex(N2kMsg.Destination);
-  
+
     if ( N2kMsg.Destination!=0xff && iDev==-1) return; // if destination is not for us, we do nothing
-    
+
     ParseN2kPGNISORequest(N2kMsg,RequestedPGN);
 //    Serial.print("ISO request: "); Serial.println(RequestedPGN);
     if (N2kMsg.Destination==0xff) { // broadcast -> respond from all devices
@@ -787,19 +787,19 @@ void tNMEA2000::HandleISORequest(const tN2kMsg &N2kMsg) {
 void tNMEA2000::HandleISOAddressClaim(const tN2kMsg &N2kMsg) {
   int iDev=FindSourceDeviceIndex(N2kMsg.Source);
   if ( iDev==-1 ) return; // if the address is not same as we have, we do nothing
-  
+
   uint64_t *CallerName;
 
     CallerName=(uint64_t *)(N2kMsg.Data);
-    
+
     if (DeviceInformation[iDev].GetName()<*CallerName) { // We can keep our address, so just reclaim it
       SendIsoAddressClaim(0xff,iDev);
     } else { // we have to try an other address
-      if (DeviceInformation[iDev].GetName()==*CallerName) { 
-        // If the name is same, then the first instance will get claim and change its address. 
+      if (DeviceInformation[iDev].GetName()==*CallerName) {
+        // If the name is same, then the first instance will get claim and change its address.
         // This should not happen, if user takes care of setting unique ID for device information.
         // If he does not there is no problem with this class, but e.g. Garmin gets crazy.
-        // Try to solve situation by changing our device instance. 
+        // Try to solve situation by changing our device instance.
         DeviceInformation[iDev].SetDeviceInstance(DeviceInformation[iDev].GetDeviceInstance()+1);
       }
       GetNextAddress(iDev);
@@ -813,7 +813,7 @@ void tNMEA2000::HandleISOAddressClaim(const tN2kMsg &N2kMsg) {
 //*****************************************************************************
 bool tNMEA2000::ReadResetAddressChanged() {
   bool result=AddressChanged;
-  
+
   AddressChanged=false;
   return result;
 }
@@ -824,8 +824,8 @@ void tNMEA2000::GetNextAddress(int DeviceIndex) {
   // Currently simply add address
   // Note that 253 is the last source. We do not send data if address is higher than that.
   do {
-    if (DeviceInformation[DeviceIndex].N2kSource<255) DeviceInformation[DeviceIndex].N2kSource++; 
-    
+    if (DeviceInformation[DeviceIndex].N2kSource<255) DeviceInformation[DeviceIndex].N2kSource++;
+
     // Check that we do not have same on our list
     for (int i=0; i<DeviceCount && !FoundSame; i++) {
       if (i!=DeviceIndex) FoundSame=(DeviceInformation[DeviceIndex].N2kSource==DeviceInformation[i].N2kSource);
@@ -838,7 +838,7 @@ bool tNMEA2000::HandleReceivedSystemMessage(int MsgIndex) {
   bool result=false;
 
    if ( N2kMode==N2km_SendOnly || N2kMode==N2km_ListenAndSend ) return result;
-    
+
     if ( N2kCANMsgBuf[MsgIndex].SystemMessage ) {
       if ( ForwardSystemMessages() ) ForwardMessage(N2kCANMsgBuf[MsgIndex].N2kMsg);
       if ( N2kMode!=N2km_ListenOnly ) { // Note that in listen only mode we will not inform us to the bus
@@ -855,7 +855,7 @@ bool tNMEA2000::HandleReceivedSystemMessage(int MsgIndex) {
       }
       result=true;
     }
-  
+
   return result;
 }
 
@@ -868,12 +868,12 @@ void tNMEA2000::ParseMessages() {
     static const int MaxReadFramesOnParse=20;
     int FramesRead=0;
 //    tN2kMsg N2kMsg;
-  
+
     if (!Open()) return;  // Can not do much
-    
+
     SendFrames();
     SendPendingInformation();
-    
+
     while (FramesRead<MaxReadFramesOnParse && CANGetFrame(canId,len,buf) ) {           // check if data coming
         FramesRead++;
 //        ForwardStream->print("Can ID:"); ForwardStream->print(canId); ForwardStream->print(" len:"); ForwardStream->print(len); ForwardStream->print(" data:"); PrintBuf(ForwardStream,len,buf); ForwardStream->println("\r\n");
@@ -889,7 +889,7 @@ void tNMEA2000::ParseMessages() {
 //          Serial.print(MsgIndex); Serial.print("\r\n");
         }
     }
-    
+
 }
 
 //*****************************************************************************
@@ -919,14 +919,14 @@ void SetN2kPGN59392(tN2kMsg &N2kMsg, unsigned char Control, unsigned char GroupF
 }
 
 //*****************************************************************************
-// ISO Address Claim 
+// ISO Address Claim
 void SetN2kPGN60928(tN2kMsg &N2kMsg, unsigned long UniqueNumber, int ManufacturerCode,
                    unsigned char DeviceFunction, unsigned char DeviceClass,
                    unsigned char DeviceInstance, unsigned char SystemInstance, unsigned char IndustryGroup
                    ) {
     N2kMsg.SetPGN(60928L);
     N2kMsg.Priority=6;
-    
+
     N2kMsg.Add4ByteUInt((UniqueNumber&0x1FFFFF) | ((unsigned long)(ManufacturerCode&0x7ff))<<21);
     N2kMsg.AddByte(DeviceInstance);
     N2kMsg.AddByte(DeviceFunction);
@@ -935,18 +935,18 @@ void SetN2kPGN60928(tN2kMsg &N2kMsg, unsigned long UniqueNumber, int Manufacture
 }
 
 //*****************************************************************************
-// ISO Address Claim 
+// ISO Address Claim
 void SetN2kPGN60928(tN2kMsg &N2kMsg, uint64_t Name) {
     N2kMsg.SetPGN(60928L);
     N2kMsg.Priority=6;
-    
+
     N2kMsg.AddUInt64(Name);
 }
 
 //*****************************************************************************
 // Product Information
 void SetN2kPGN126996(tN2kMsg &N2kMsg, unsigned int N2kVersion, unsigned int ProductCode,
-                     const char *ModelID, const char *SwCode, 
+                     const char *ModelID, const char *SwCode,
                      const char *ModelVersion, const char *ModelSerialCode,
                      unsigned char SertificationLevel, unsigned char LoadEquivalency) {
 
@@ -975,11 +975,11 @@ void SetN2kPGN126998(tN2kMsg &N2kMsg,
   int ManInfoLen=(ManufacturerInformation?strlen(ManufacturerInformation):0);
   int InstDesc1Len=(InstallationDescription1?strlen(InstallationDescription1):0);
   int InstDesc2Len=(InstallationDescription2?strlen(InstallationDescription2):0);
-  
+
     if ( ManInfoLen>Max_conf_info_field_len ) ManInfoLen=Max_conf_info_field_len;
     if ( InstDesc1Len>Max_conf_info_field_len ) InstDesc1Len=Max_conf_info_field_len;
     if ( InstDesc2Len>Max_conf_info_field_len ) InstDesc2Len=Max_conf_info_field_len;
-  
+
     TotalLen=0;
     if (TotalLen+ManInfoLen>MaxLen) ManInfoLen=MaxLen-TotalLen;
     TotalLen+=ManInfoLen;
@@ -987,7 +987,7 @@ void SetN2kPGN126998(tN2kMsg &N2kMsg,
     TotalLen+=InstDesc1Len;
     if (TotalLen+InstDesc2Len>MaxLen) InstDesc2Len=MaxLen-TotalLen;
     TotalLen+=InstDesc2Len;
-  
+
     N2kMsg.SetPGN(126998L);
     N2kMsg.Priority=6;
     // InstallationDescription1
@@ -1016,10 +1016,10 @@ void SetN2kPGN59904(tN2kMsg &N2kMsg, uint8_t Destination, unsigned long Requeste
 bool ParseN2kPGN59904(const tN2kMsg &N2kMsg, unsigned long &RequestedPGN) {
   int result=((N2kMsg.DataLen>=3) && (N2kMsg.DataLen<=8));
   RequestedPGN=0;
-  
+
   if (result) {
     RequestedPGN=((unsigned long)N2kMsg.Data[2])<<16 | ((unsigned long)N2kMsg.Data[1]) << 8 | ((unsigned long)N2kMsg.Data[0]);
   }
-  
+
   return result;
 }


### PR DESCRIPTION
"- Fix an issue where setting single- and multi frame messages always reverted back to default messages."

It seems to be a minor copy/paste error caught by the compiler:

> comparison of array X equal to a null pointer is always false