### PR TITLE
Endian and alignment

### DIFF
--- a/N2kMsg.cpp
+++ b/N2kMsg.cpp
@@ -367,25 +367,29 @@ int64_t byteswap(int64_t val) {
 //*****************************************************************************
 template<typename T>
 T GetBuf(size_t len, int& index, const unsigned char* buf) {
-  T v{};
-  memcpy(&v, &buf[index], len);
+  T v{0};
+  
+  // This could be improved by casting the buffer to a pointer of T and
+  // doing a direct copy. That is, if unaligned data access is allowed.  
+  memcpy(&v, &buf[index], len);  
+  index += len;
 
 #if defined(HOST_IS_BIG_ENDIAN)
   v = byteswap(v);
 #endif
 
-  index += len;
   return v;
 }
 
 //*****************************************************************************
 template<typename T>
 void SetBuf(T v, size_t len, int& index, unsigned char* buf) {
-
 #if defined(HOST_IS_BIG_ENDIAN)
   v = byteswap(v);
 #endif
-
+  
+  // This could be improved by casting the buffer to a pointer of T and
+  // doing a direct copy. That is, if unaligned data access is allowed. 
   memcpy(&buf[index], &v, len);
   index += len;
 }


### PR DESCRIPTION
This patch does two things:
- Adds support for big endian targets
- Adds support for tagets which do now allow unaligned memory access.

Some targets require that data reside on certain memory address alignments. AVR32, for example, has 16- and 32-bit requirements, so if you try to cast a non-aligned address to a data pointer you will get an exception and the MCU will halt execution. This patch copes the data in a more friendly (but slower) way using memcpy.

There is room for optimizations here though. If we want to we can assume that some targets like x86 and AVR8 (and possibly some ARMs) do allow for unaligned memory access and we resort back to the old cast method for those cases. However, I do not recommend it unless the memcpy way if substantially larger or slower in the general case.