### PR TITLE
Compatibility fixes.

### DIFF
--- a/N2kMessages.h
+++ b/N2kMessages.h
@@ -585,7 +585,7 @@ tN2kOnOff N2kGetStatusOnBinaryStatus(tN2kBinaryStatus BankStatus, uint8_t ItemIn
 
 //*****************************************************************************
 // Reset all single binary status values to not available
-inline void N2kResetBinaryStatus(tN2kBinaryStatus &BankStatus) { BankStatus=0xffffffffffffffff; }
+inline void N2kResetBinaryStatus(tN2kBinaryStatus &BankStatus) { BankStatus=0xffffffffffffffffULL; }
 
 //*****************************************************************************
 // Set single status to full binary bank status.

--- a/N2kMsg.h
+++ b/N2kMsg.h
@@ -119,7 +119,7 @@ public:
   uint16_t Get2ByteUInt(int &Index, uint16_t def=0xffff) const;
   uint32_t Get3ByteUInt(int &Index, uint32_t def=0xffffffff) const;
   uint32_t Get4ByteUInt(int &Index, uint32_t def=0xffffffff) const;
-  uint64_t GetUInt64(int &Index, uint64_t def=0xffffffffffffffff) const;
+  uint64_t GetUInt64(int &Index, uint64_t def=0xffffffffffffffffULL) const;
   double Get1ByteDouble(double precision, int &Index, double def=N2kDoubleNA) const;
   double Get1ByteUDouble(double precision, int &Index, double def=N2kDoubleNA) const;
   double Get2ByteDouble(double precision, int &Index, double def=N2kDoubleNA) const;

--- a/N2kStream.cpp
+++ b/N2kStream.cpp
@@ -51,4 +51,8 @@ size_t N2kStream::println(const char *str) {
    return print(str) + print("\r\n");
 }
 
+size_t N2kStream::println(int val, uint8_t radix) {
+   return print(val, radix) + print("\r\n");
+}
+
 #endif

--- a/N2kStream.h
+++ b/N2kStream.h
@@ -62,6 +62,9 @@ class N2kStream {
 
    // Print string and newline to stream.
    size_t println(const char *str);
+
+   // Print value and newline to stream.
+   size_t println(int val, uint8_t radix = 10);
 };
 #endif
 


### PR DESCRIPTION
Fix compiler warning (non 64bit compatibility fix) and implement pritln for integers.

Without this I believe the 64bit default values might be broken on systems which has smaller width for 'int'.