### PR TITLE
Explicitly set type of DeviceIndetifier.GetUniqueNumber()

### DIFF
--- a/N2kGroupFunctionDefaultHandlers.cpp
+++ b/N2kGroupFunctionDefaultHandlers.cpp
@@ -77,7 +77,7 @@ bool tN2kGroupFunctionHandlerForPGN60928::HandleRequest(const tN2kMsg &N2kMsg,
         field=N2kMsg.GetByte(Index);
         switch (field) {
           case N2kPGN60928_UniqueNumber_field: 
-            MatchRequestField(N2kMsg.Get4ByteUInt(Index),DI.GetUniqueNumber(),(uint32_t)0x001fffff,MatchFilter,FieldErrorCode);
+            MatchRequestField(N2kMsg.Get4ByteUInt(Index),(uint32_t)DI.GetUniqueNumber(),(uint32_t)0x001fffff,MatchFilter,FieldErrorCode);
             break;
           case N2kPGN60928_ManufacturerCode_field: 
             MatchRequestField(N2kMsg.Get2ByteUInt(Index),DI.GetManufacturerCode(),(uint16_t)0x07ff,MatchFilter,FieldErrorCode);


### PR DESCRIPTION
Without this change, the project does not compile on my ESP8266 target because `unsigned long` is different than `unsigned int`. I guess this will affect more platform.

````
Compiling .pioenvs/esp/lib/NMEA2000/N2kMsg.o
lib/NMEA2000/N2kGroupFunctionDefaultHandlers.cpp: In member function 'virtual bool  N2kGroupFunctionHandlerForPGN60928::HandleRequest(const tN2kMsg&, uint32_t, uint16_t, uint8_t, int)':
lib/NMEA2000/N2kGroupFunctionDefaultHandlers.cpp:80:126: error: no matching function for call to 'MatchRequestField(uint32_t, long unsigned int, uint32_t, bool&, tN2kGroupFunctionParameterErrorCode&)'
MatchRequestField(N2kMsg.Get4ByteUInt(Index),DI.GetUniqueNumber(),(uint32_t)0x001fffff,MatchFilter,FieldErrorCode);
^
lib/NMEA2000/N2kGroupFunctionDefaultHandlers.cpp:80:126: note: candidate is:
lib/NMEA2000/N2kGroupFunctionDefaultHandlers.cpp:38:28: note: template<class T> void MatchRequestField(T, T, T, bool&, tN2kGroupFunctionParameterErrorCode&)
template <typename T> void MatchRequestField(T FieldVal, T MatchVal, T Mask, bool &Match, tN2kGroupFunctionParameterErrorCode &ErrorCode)
^
lib/NMEA2000/N2kGroupFunctionDefaultHandlers.cpp:38:28: note:   template argument deduction/substitution failed:
lib/NMEA2000/N2kGroupFunctionDefaultHandlers.cpp:80:126: note:   deduced conflicting types for parameter 'T' ('unsigned int' and 'long unsigned int')
MatchRequestField(N2kMsg.Get4ByteUInt(Index),DI.GetUniqueNumber(),(uint32_t)0x001fffff,MatchFilter,FieldErrorCode);
^
*** [.pioenvs/esp/lib/NMEA2000/N2kGroupFunctionDefaultHandlers.o] Error 1
````
Maybe a better fix would be to change DI.GetUniqueNumber() to return an explicitly sized type?

The implementation of DI.GetUniqueNumber() will clearly always return less than 32 bits:
````
unsigned long GetUniqueNumber() { return DeviceInformation.UnicNumberAndManCode&0x1fffff; }
````