### PR TITLE
Do not redefine F() if it's already defined

### DIFF
--- a/N2kDef.h
+++ b/N2kDef.h
@@ -58,7 +58,9 @@ extern uint32_t millis();
 class __FlashStringHelper;
 #define F(str) (reinterpret_cast<const __FlashStringHelper*>(PSTR(str)))
 #else
+#ifndef F
 #define F(str) str
+#endif
 #endif
 
 #endif


### PR DESCRIPTION
This removes a Warning when compiling KBox tests because I already define F to be a no-op in other headers. I think checking whether F() is defined before re-defining it is the proper thing to do here.