### PR TITLE
Do not redefine macro BIT(x) if already defined

### DIFF
--- a/src/N2kMsg.h
+++ b/src/N2kMsg.h
@@ -38,7 +38,9 @@ const uint16_t N2kUInt16NA=0xffff;
 const int16_t  N2kInt16NA=0x7fff;
 const uint32_t N2kUInt32NA=0xffffffff;
 const int32_t  N2kInt32NA=0x7fffffff;
+#ifndef BIT
 #define BIT(n) (1 << n)
+#endif
 
 inline bool N2kIsNA(double v) { return v==N2kDoubleNA; }
 inline bool N2kIsNA(uint8_t v) { return v==N2kUInt8NA; }


### PR DESCRIPTION
Fixes a build warning when building NMEA2000 on espruino.