### PR TITLE
The Arduino framework for ESP8266 defines pgm_*

### DIFF
--- a/src/N2kDef.h
+++ b/src/N2kDef.h
@@ -41,10 +41,13 @@ extern uint32_t millis();
 
 // Declare PROGMEM macros to nothing on non-AVR targets.
 #if !defined(__AVR__) && !defined(ARDUINO)
+// ESP8266 provides it's own definition - Do not override it.
+#if !defined(ARDUINO_ARCH_ESP8266)
 #define PROGMEM
 #define pgm_read_byte(var)  *var
 #define pgm_read_word(var)  *var
 #define pgm_read_dword(var) *var
+#endif
 #endif
 
 // Definition for the F(str) macro. On Arduinos use what the framework


### PR DESCRIPTION
We should not override those definitions.