### PR TITLE
Added test in pre-processor before using value

### DIFF
--- a/N2kMsg.cpp
+++ b/N2kMsg.cpp
@@ -37,7 +37,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // NMEA2000 uses little endian for binary data. Swap the endian if we are
 // running on a big endian machine. There is no reliable, portable compile
 // check for this so each compiler has to be added manually.
-#if defined(__GNUC__)
+#if defined(__GNUC__) && defined (__BYTE_ORDER__)
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define HOST_IS_BIG_ENDIAN
 #endif

--- a/N2kMsg.cpp
+++ b/N2kMsg.cpp
@@ -337,9 +337,9 @@ int16_t byteswap(int16_t val)
 template<>
 uint32_t byteswap(uint32_t val) {
   return ((val << 24)) |
-      ((val << 8)  & 0xff00000000ULL) |
-      ((val >> 8)  & 0xff000000ULL) |
-      ((val >> 24) & 0xff0000ULL);
+      ((val << 8)  & 0xff0000UL) |
+      ((val >> 8)  & 0xff00UL) |
+      ((val >> 24));
 }
 
 template<>


### PR DESCRIPTION
If __BYTE_ORDER__ ....  is not defined, the test resolved to TRUE .

Adding check to see if value is even declared before testing its BIG vs. LITTLE endian
