### PR TITLE
Use min/max from STL.

### DIFF
--- a/src/N2kGroupFunctionDefaultHandlers.cpp
+++ b/src/N2kGroupFunctionDefaultHandlers.cpp
@@ -24,6 +24,8 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "N2kGroupFunctionDefaultHandlers.h"
 #include "NMEA2000.h"
 
+#include <algorithm>
+
 #define N2kPGN60928_UniqueNumber_field 1
 #define N2kPGN60928_ManufacturerCode_field 2
 #define N2kPGN60928_DeviceInstanceLower_field 3
@@ -294,7 +296,7 @@ bool tN2kGroupFunctionHandlerForPGN126996::HandleRequest(const tN2kMsg &N2kMsg,
     uint8_t field;
     tN2kGroupFunctionParameterErrorCode FieldErrorCode;
     bool FoundInvalidField=false;
-    size_t strSize=max(Max_N2kModelID_len+1,max(Max_N2kSwCode_len+1,max(Max_N2kModelVersion_len+1,Max_N2kModelSerialCode_len+1)));
+    size_t strSize=std::max(Max_N2kModelID_len+1, std::max(Max_N2kSwCode_len+1, std::max(Max_N2kModelVersion_len+1, Max_N2kModelSerialCode_len+1)));
     char Query[strSize];
     char CurVal[strSize];
     

--- a/src/NMEA2000.cpp
+++ b/src/NMEA2000.cpp
@@ -28,6 +28,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #endif
 #include <string.h>
 #include <stdlib.h>
+#include <algorithm>
 
 #define DebugStream Serial
 
@@ -839,7 +840,7 @@ bool tNMEA2000::SendFrame(unsigned long id, unsigned char len, const unsigned ch
       N2kFrameOutDbg("Frame failed "); N2kFrameOutDbgln(id);
       return false;
     }
-    len=max(len,8);
+    len=std::max(int(len), 8);
     Frame->id=id;
     Frame->len=len;
     Frame->wait_sent=wait_sent;
@@ -1086,7 +1087,7 @@ void tNMEA2000::FindFreeCANMsgIndex(unsigned long PGN, unsigned char Source, uin
 
 #if !defined(N2K_NO_ISO_MULTI_PACKET_SUPPORT)
 
-unsigned char TPCtsPackets(unsigned char nPackets) { return max(1,min(nPackets,TP_MAX_FRAMES)); }
+unsigned char TPCtsPackets(unsigned char nPackets) { return std::max(1, std::min(int(nPackets), TP_MAX_FRAMES)); }
 
 //*****************************************************************************
 void tNMEA2000::SendTPCM_CTS(unsigned long PGN, unsigned char Destination, unsigned char Source, unsigned char nPackets, unsigned char NextPacketNumber) {


### PR DESCRIPTION
This fixes build issues on systems which do not have inherent min/max macros.

I have not ensured that this still builds in Arduino.