### PR TITLE
add pgn130576 Small Craft Status / Trim Tab Position

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,7 +63,7 @@ support.
 
 == Changes ==
 29.01.2018
-- Added PGN130576 Small Craft Status / Trim Tab Position definition.
+- Added: PGN130576 Small Craft Status / Trim Tab Position definition by Nicholas Agro
 
 15.01.2018
 

--- a/README.adoc
+++ b/README.adoc
@@ -62,6 +62,9 @@ support.
 
 
 == Changes ==
+29.01.2018
+- Added PGN130576 Small Craft Status / Trim Tab Position definition.
+
 15.01.2018
 
 - Fix: ParseN2kPGN129284, Index was not initialized to 0, which caused unpredictable read.

--- a/library.json
+++ b/library.json
@@ -9,12 +9,12 @@
   },
   "authors":
   {
-    "name": "Timo Lappalainen,Nicholas Agro",
+    "name": "Timo Lappalainen",
     "email": " ",
     "url": "Kave Oy <www.kave.fi>",
     "maintainer": true
   },
-  "version": "4.4.1",
+  "version": "4.4.2",
   "license": "MIT",
   "frameworks": "*",
   "platforms": "*"

--- a/library.json
+++ b/library.json
@@ -9,7 +9,7 @@
   },
   "authors":
   {
-    "name": "Timo Lappalainen",
+    "name": "Timo Lappalainen,Nicholas Agro",
     "email": " ",
     "url": "Kave Oy <www.kave.fi>",
     "maintainer": true

--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
 name=NMEA2000
 version=4.4.1
-author=Timo Lappalainen
+author=Timo Lappalainen,Nicholas Agro
 maintainer=Kave Oy <www.kave.fi>
 sentence=NMEA 2000 library for building compatible devices for NMEA 2000 bus.
 paragraph=The NMEA2000 library feature: NMEA2000->PC interface, NMEA2000 device node

--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
 name=NMEA2000
-version=4.4.1
-author=Timo Lappalainen,Nicholas Agro
+version=4.4.2
+author=Timo Lappalainen
 maintainer=Kave Oy <www.kave.fi>
 sentence=NMEA 2000 library for building compatible devices for NMEA 2000 bus.
 paragraph=The NMEA2000 library feature: NMEA2000->PC interface, NMEA2000 device node

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -1375,3 +1375,34 @@ bool ParseN2kPGN130316(const tN2kMsg &N2kMsg, unsigned char &SID, unsigned char 
 
   return true;
 }
+
+//*****************************************************************************
+// Trim Tab Position
+// Trim tab position is a percentage 0 to 100% where 0 is fully retracted and 100 is fully extended
+void SetN2kPGN130576(tN2kMsg &N2kMsg, unsigned char PortTrimTab, unsigned char StbdTrimTab) {
+    N2kMsg.SetPGN(130576L);
+    N2kMsg.Priority=6;
+    N2kMsg.AddByte(PortTrimTab);
+    N2kMsg.AddByte(StbdTrimTab);
+    N2kMsg.AddByte(0xff); // Reserved
+    N2kMsg.AddByte(0xff); // Pad bytes as added by Garmin GBT10
+    N2kMsg.AddByte(0xff); // Pad bytes as added by Garmin GBT10
+    N2kMsg.AddByte(0xff); // Pad bytes as added by Garmin GBT10
+    N2kMsg.AddByte(0xff); // Pad bytes as added by Garmin GBT10
+    N2kMsg.AddByte(0xff); // Pad bytes as added by Garmin GBT10
+}
+
+bool ParseN2kPGN130576(const tN2kMsg &N2kMsg, unsigned char &PortTrimTab, unsigned char &StbdTrimTab) {
+                     
+  if (N2kMsg.PGN!=130576L) return false;
+  int Index=0;
+  PortTrimTab=N2kMsg.GetByte(Index);
+  StbdTrimTab=N2kMsg.GetByte(Index);
+  
+  return true;
+}
+
+
+
+
+

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -1379,20 +1379,15 @@ bool ParseN2kPGN130316(const tN2kMsg &N2kMsg, unsigned char &SID, unsigned char 
 //*****************************************************************************
 // Trim Tab Position
 // Trim tab position is a percentage 0 to 100% where 0 is fully retracted and 100 is fully extended
-void SetN2kPGN130576(tN2kMsg &N2kMsg, unsigned char PortTrimTab, unsigned char StbdTrimTab) {
+void SetN2kPGN130576(tN2kMsg &N2kMsg, int8_t PortTrimTab, int8_t StbdTrimTab) {
     N2kMsg.SetPGN(130576L);
     N2kMsg.Priority=6;
     N2kMsg.AddByte(PortTrimTab);
     N2kMsg.AddByte(StbdTrimTab);
-    N2kMsg.AddByte(0xff); // Reserved
-    N2kMsg.AddByte(0xff); // Pad bytes as added by Garmin GBT10
-    N2kMsg.AddByte(0xff); // Pad bytes as added by Garmin GBT10
-    N2kMsg.AddByte(0xff); // Pad bytes as added by Garmin GBT10
-    N2kMsg.AddByte(0xff); // Pad bytes as added by Garmin GBT10
-    N2kMsg.AddByte(0xff); // Pad bytes as added by Garmin GBT10
+    N2kMsg.Add2ByteUInt(0xffff); N2kMsg.Add4ByteUInt(0xffffffff);// Reserved. Using 6 bytes as shown in messages from Garmin GBT10
 }
 
-bool ParseN2kPGN130576(const tN2kMsg &N2kMsg, unsigned char &PortTrimTab, unsigned char &StbdTrimTab) {
+bool ParseN2kPGN130576(const tN2kMsg &N2kMsg, int8_t &PortTrimTab, int8_t &StbdTrimTab) {
                      
   if (N2kMsg.PGN!=130576L) return false;
   int Index=0;

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -1384,7 +1384,7 @@ void SetN2kPGN130576(tN2kMsg &N2kMsg, int8_t PortTrimTab, int8_t StbdTrimTab) {
     N2kMsg.Priority=6;
     N2kMsg.AddByte(PortTrimTab);
     N2kMsg.AddByte(StbdTrimTab);
-    N2kMsg.Add2ByteUInt(0xffff); N2kMsg.Add4ByteUInt(0xffffffff);// Reserved. Using 6 bytes as shown in messages from Garmin GBT10
+    N2kMsg.AddByte(0xFF);;// Reserved.
 }
 
 bool ParseN2kPGN130576(const tN2kMsg &N2kMsg, int8_t &PortTrimTab, int8_t &StbdTrimTab) {

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -1428,15 +1428,15 @@ inline bool ParseN2kTemperatureExt(const tN2kMsg &N2kMsg, unsigned char &SID, un
 
 // Output:
 //  - N2kMsg                NMEA2000 message ready to be send.
-void SetN2kPGN130576(tN2kMsg &N2kMsg, unsigned char PortTrimTab, unsigned char StbdTrimTab);
+void SetN2kPGN130576(tN2kMsg &N2kMsg, int8_t PortTrimTab, int8_t StbdTrimTab);
 
-inline void SetN2kTrimTab(tN2kMsg &N2kMsg, unsigned char PortTrimTab, unsigned char StbdTrimTab){
+inline void SetN2kTrimTab(tN2kMsg &N2kMsg, int8_t PortTrimTab, int8_t StbdTrimTab){
                      
   SetN2kPGN130576(N2kMsg,PortTrimTab, StbdTrimTab);
 }
 
-bool ParseN2kPGN130576(const tN2kMsg &N2kMsg, unsigned char &PortTrimTab, unsigned char &StbdTrimTab);
-inline bool ParseN2kTrimTab(const tN2kMsg &N2kMsg, unsigned char &PortTrimTab, unsigned char &StbdTrimTab) {
+bool ParseN2kPGN130576(const tN2kMsg &N2kMsg, int8_t &PortTrimTab, int8_t &StbdTrimTab);
+inline bool ParseN2kTrimTab(const tN2kMsg &N2kMsg, int8_t &PortTrimTab, int8_t &StbdTrimTab) {
   return ParseN2kPGN130576(N2kMsg, PortTrimTab, StbdTrimTab);
 }
 

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -1418,4 +1418,29 @@ inline bool ParseN2kTemperatureExt(const tN2kMsg &N2kMsg, unsigned char &SID, un
   return ParseN2kPGN130316(N2kMsg, SID, TempInstance, TempSource, ActualTemperature, SetTemperature);
 }
 
+
+//*****************************************************************************
+// Small Craft Status (Trim Tab Position)
+// Trim tab position is a percentage 0 to 100% where 0 is fully retracted and 100 is fully extended
+// Input:
+//  - PortTrimTab           Port trim tab position
+//  - StbdTrimTab           Starboard trim tab position
+
+// Output:
+//  - N2kMsg                NMEA2000 message ready to be send.
+void SetN2kPGN130576(tN2kMsg &N2kMsg, unsigned char PortTrimTab, unsigned char StbdTrimTab);
+
+inline void SetN2kTrimTab(tN2kMsg &N2kMsg, unsigned char PortTrimTab, unsigned char StbdTrimTab){
+                     
+  SetN2kPGN130576(N2kMsg,PortTrimTab, StbdTrimTab);
+}
+
+bool ParseN2kPGN130576(const tN2kMsg &N2kMsg, unsigned char &PortTrimTab, unsigned char &StbdTrimTab);
+inline bool ParseN2kTrimTab(const tN2kMsg &N2kMsg, unsigned char &PortTrimTab, unsigned char &StbdTrimTab) {
+  return ParseN2kPGN130576(N2kMsg, PortTrimTab, StbdTrimTab);
+}
+
+
+
+
 #endif

--- a/src/NMEA2000.cpp
+++ b/src/NMEA2000.cpp
@@ -185,6 +185,7 @@ bool IsDefaultSingleFrameMessage(unsigned long PGN) {
                                       case 130312L: // Temperature
                                       case 130314L: // Pressure
                                       case 130316L: // Temperature extended range
+                                      case 130576L: // Small Craft Status (Trim Tab position)
                                       return true;
                                   }
                                   return false;


### PR DESCRIPTION
Add PGN130756 Small Craft Status / Trim Tab Position. 
Nicholas Agro 1/28/2018

Testing and validation performed:
- Successfully used this PGN to read and display Trim Tab Position from Garmin GBT 10 Trim Tab Position sender unit
- Successfully read Trim Tab Position messages output from this PGN on Actisense NMEA reader
- Succesfully displayed Trim Tab Position from this PGN on Garmin 4212 Chartplotter display