### PR TITLE
Adding PORT config ability to SocketCAN

### DIFF
--- a/src/NMEA2000_CAN.h
+++ b/src/NMEA2000_CAN.h
@@ -94,8 +94,11 @@ tNMEA2000 &NMEA2000=*(new tNMEA2000_avr());
 
 #elif USE_N2K_CAN == USE_N2K_SOCKET_CAN
 // Use socketCAN devices
+#ifndef SOCKET_CAN_PORT
+  #define SOCKET_CAN_PORT NULL
+  #endif
 #include <NMEA2000_SocketCAN.h>       // https://github.com/thomasonw/NMEA2000_socketCAN
-tNMEA2000 &NMEA2000=*(new tNMEA2000_SocketCAN());
+tNMEA2000 &NMEA2000=*(new tNMEA2000_SocketCAN(SOCKET_CAN_PORT));
 tSocketStream serStream;
 
 #elif USE_N2K_CAN == USE_N2K_MBED_CAN


### PR DESCRIPTION
Moving ability to select which CAN port is used as the source for SocektCAN to constructor time to be more consistent with other styles (ala, MCP2551).

Requires usage of updated socketCAN libs