### PR TITLE
Make ESP32 work with ESP-IDF framework

### DIFF
--- a/src/NMEA2000_CAN.h
+++ b/src/NMEA2000_CAN.h
@@ -73,7 +73,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define USE_N2K_CAN USE_N2K_AVR_CAN
 #elif defined(__linux__)||defined(__linux)||defined(linux)
 #define USE_N2K_CAN USE_N2K_SOCKET_CAN
-#elif defined(ARDUINO_ARCH_ESP32)
+#elif defined(ARDUINO_ARCH_ESP32) || defined(ESP32)
 #define USE_N2K_CAN USE_N2K_ESP32_CAN
 #else
 #define USE_N2K_CAN USE_N2K_MCP_CAN


### PR DESCRIPTION
This makes autodetection of the CAN driver works when building with just ESP-IDF (without the Arduino layer).