### PR TITLE
Fix capitals in includes to compile the esp32 example on Linux

### DIFF
--- a/Examples/ESP32/NMEA2000ToWiFiAsSeaSmart/NMEA2000ToWiFiAsSeaSmart.ino
+++ b/Examples/ESP32/NMEA2000ToWiFiAsSeaSmart/NMEA2000ToWiFiAsSeaSmart.ino
@@ -3,14 +3,14 @@
 // The code has been tested with ESP32.
 
 #include <NMEA2000_CAN.h>
-#include <SeaSmart.h>
+#include <Seasmart.h>
 #include <WiFi.h>
 #include <nvs.h>
 #include <nvs_flash.h>
-#include <Memory>
+#include <memory>
 #include "N2kDataToNMEA0183.h"
 #include "BoardSerialNumber.h"
-#include "list.h"
+#include "List.h"
 
 // Define your default settings here
 const char* ssid     = "Guest";


### PR DESCRIPTION
Fix some capitals in the includes of the esp32 example so it compiles on Linux