### PR TITLE
Add wind support to ESP32 example

### DIFF
--- a/Examples/ESP32/NMEA2000ToWiFiAsSeaSmart/N2kDataToNMEA0183.h
+++ b/Examples/ESP32/NMEA2000ToWiFiAsSeaSmart/N2kDataToNMEA0183.h
@@ -38,10 +38,13 @@ protected:
   double Heading;
   double COG;
   double SOG;
+  double WindSpeed;
+  double WindAngle;
   unsigned long LastHeadingTime;
   unsigned long LastCOGSOGTime;
   unsigned long LastPositionTime;
   unsigned long LastPosSend;
+  unsigned long LastWindTime;
   uint16_t DaysSince1970;
   double SecondsSinceMidnight;
   unsigned long NextRMCSend;
@@ -57,6 +60,7 @@ protected:
   void HandlePosition(const tN2kMsg &N2kMsg); // 129025
   void HandleCOGSOG(const tN2kMsg &N2kMsg); // 129026
   void HandleGNSS(const tN2kMsg &N2kMsg); // 129029
+  void HandleWind(const tN2kMsg &N2kMsg); // 130306
   void SetNextRMCSend() { NextRMCSend=millis()+RMCPeriod; }
   void SendRMC();
   void SendMessage(const tNMEA0183Msg &NMEA0183Msg);
@@ -73,6 +77,7 @@ public:
     LastHeadingTime=0;
     LastCOGSOGTime=0;
     LastPositionTime=0;
+    LastWindTime=0;
   }
   void HandleMsg(const tN2kMsg &N2kMsg);
   void SetSendNMEA0183MessageCallback(tSendNMEA0183MessageCallback _SendNMEA0183MessageCallback) {

--- a/Examples/ESP32/NMEA2000ToWiFiAsSeaSmart/NMEA2000ToWiFiAsSeaSmart.ino
+++ b/Examples/ESP32/NMEA2000ToWiFiAsSeaSmart/NMEA2000ToWiFiAsSeaSmart.ino
@@ -40,6 +40,7 @@ const unsigned long ReceiveMessages[] PROGMEM={/*126992L,*/ // System time
                                               129025UL,// Position
                                               129026L, // COG and SOG
                                               129029L, // GNSS
+                                              130306L, // Wind
                                               0};
 
 // Forward declarations

--- a/Examples/ESP32/NMEA2000ToWiFiAsSeaSmart/NMEA2000ToWiFiAsSeaSmart.ino
+++ b/Examples/ESP32/NMEA2000ToWiFiAsSeaSmart/NMEA2000ToWiFiAsSeaSmart.ino
@@ -32,7 +32,15 @@ tN2kDataToNMEA0183 tN2kDataToNMEA0183(&NMEA2000, 0);
 
 // Set the information for other bus devices, which messages we support
 const unsigned long TransmitMessages[] PROGMEM={0};
-const unsigned long ReceiveMessages[] PROGMEM={/*126992L,*/127250L,127258L,128259UL,128267UL,129025UL,129026L,129029L,0};
+const unsigned long ReceiveMessages[] PROGMEM={/*126992L,*/ // System time
+                                              127250L, // Heading
+                                              127258L, // Magnetic variation
+                                              128259UL,// Boat speed
+                                              128267UL,// Depth
+                                              129025UL,// Position
+                                              129026L, // COG and SOG
+                                              129029L, // GNSS
+                                              0};
 
 // Forward declarations
 void LedOn(unsigned long OnTime);


### PR DESCRIPTION
Decode NMEA2000 wind message (130306) and assemble NMEA0183 message to transmit via wifi. Only Tested with the nmea simulator. Code taken from  NMEA0183/Examples/N2k-NMEA0183-N2k/N2kWindDataHandler.cpp.
