### PR TITLE
REMOVE BITFIELD TYPES WHICH WERE ERRONEOUSLY DECLARED AS ENUMS

### DIFF
--- a/src/N2kTypes.h
+++ b/src/N2kTypes.h
@@ -346,25 +346,13 @@ using tN2kGenericStatusPair = tN2kDD002;
                             // N2kDD002_1=N2kDD002_Yes
                             // N2kDD002_Unknown=N2kDD002_Unavailable
                           
-using tN2kWindlassMonitoringEvents = tN2kDD477;
-                            // N2kDD477_NoErrorsPresent=0
-                            // N2kDD477_ControllerUnderVoltageCutout=1
-                            // N2kDD477_ControllerOverCurrentCutout=2
-                            // N2kDD477_ControllerOverTemperatureCutout=4
-                            // N2kDD477_ManufacturerDefined=8
-
-using tN2kWindlassControlEvents = tN2kDD478;
-                            // N2kDD478_NoErrorsPresent=0
-                            // N2kDD478_AnotherDeviceControllingWindlass=1
-                            // N2kDD478_Reserved=14
-                          
 using tN2kWindlassMotionStates = tN2kDD480;
                             // N2kDD480_WindlassStopped=0
                             // N2kDD480_DeploymentOccurring=1
                             // N2kDD480_RetrievalOccurring=2
                             // N2kDD480_Unavailable=3
 
-using tN2kRodeTypeState = tN2kDD481;
+using tN2kRodeTypeStates = tN2kDD481;
                             // N2kDD481_ChainPresentlyDetected=0
                             // N2kDD481_RopePresentlyDetected=1
                             // N2kDD481_Error=2
@@ -375,15 +363,6 @@ using tN2kAnchorDockingStates = tN2kDD482;
                             // N2kDD482_FullyDocked=1
                             // N2kDD482_Error=2
                             // N2kDD482_DataNotAvailable=3
-
-using tN2kWindlassOperatingEvents = tN2kDD483;
-                            // N2kDD483_NoErrorsOrEventsPresent=0
-                            // N2kDD483_SystemError=1
-                            // N2kDD483_SensorError=2
-                            // N2kDD483_NoWindlassMotionDetected=4
-                            // N2kDD483_RetrievalDockingDistanceReached=8
-                            // N2kDD483_EndOfRodeReached=16
-                            // N2kDD483_Reserved=32
 
 using tN2kWindlassDirectionControl = tN2kDD484;
                             // N2kDD484_Off=0

--- a/src/NMEA2000StdTypes.h
+++ b/src/NMEA2000StdTypes.h
@@ -57,24 +57,6 @@ enum tN2kDD002 {
                             N2kDD002_Unknown=N2kDD002_Unavailable
                           };
                           
-// DD477 - Windlass Monitoring Events
-//
-enum tN2kDD477 {
-                            N2kDD477_NoErrorsPresent=0,
-                            N2kDD477_ControllerUnderVoltageCutout=1,
-                            N2kDD477_ControllerOverCurrentCutout=2,
-                            N2kDD477_ControllerOverTemperatureCutout=4,
-                            N2kDD477_ManufacturerDefined=8
-                          };
-
-// DD478 - Windlass Control Events
-//
-enum tN2kDD478 {
-                            N2kDD478_NoErrorsPresent=0,
-                            N2kDD478_AnotherDeviceControllingWindlass=1,
-                            N2kDD478_Reserved=14
-                          };
-                          
 // DD480 - Windlass Motion States
 //                          
 enum tN2kDD480 {
@@ -84,7 +66,7 @@ enum tN2kDD480 {
                             N2kDD480_Unavailable=3
                           };
 
-//  DD481 - Rode Type States
+// DD481 - Rode Type States
 //            
 enum tN2kDD481 {
                             N2kDD481_ChainPresentlyDetected=0,
@@ -100,18 +82,6 @@ enum tN2kDD482 {
                             N2kDD482_FullyDocked=1,
                             N2kDD482_Error=2,
                             N2kDD482_DataNotAvailable=3
-                          };
-
-// DD483 - Windlass Operating Events
-//                          
-enum tN2kDD483 {
-                            N2kDD483_NoErrorsOrEventsPresent=0,
-                            N2kDD483_SystemError=1,
-                            N2kDD483_SensorError=2,
-                            N2kDD483_NoWindlassMotionDetected=4,
-                            N2kDD483_RetrievalDockingDistanceReached=8,
-                            N2kDD483_EndOfRodeReached=16,
-                            N2kDD483_Reserved=32
                           };
 
 // DD484 - Windlass Direction Control


### PR DESCRIPTION
Whoops rookie error.  This update deletes the following types
from src/NMEA2000StdTypes.h and removes their usage aliases
from src/N2kTypes.h