### PR TITLE
Fix for 'memcpy' overflow

### DIFF
--- a/src/N2kMsg.cpp
+++ b/src/N2kMsg.cpp
@@ -660,7 +660,7 @@ float GetBufFloat(int &index, const unsigned char *buf, float def) {
   int32_t vl = GetBuf<int32_t>(4, index, buf);
   float ret;
   if ( !N2kIsNA(vl) ) {
-    memcpy(&ret,&vl,8);
+    memcpy(&ret,&vl,4);
     if ( isnan(ret) ) ret=def;
   } else { // On avr double==float
     ret=def;


### PR DESCRIPTION
It seems like `memcpy` will always overflow here.  The destination and source both have size 4, but memcpy size argument is 8.