### PR TITLE
Add support for Thruster Network Messages (PGNs 128006, 128007 & 128008)

### DIFF
--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -598,7 +598,7 @@ bool ParseN2kPGN128000(const tN2kMsg &N2kMsg, unsigned char &SID, double &Leeway
 
 void SetN2kPGN128006(tN2kMsg &N2kMsg, unsigned char SID, unsigned char ThrusterId, tN2kThrusterDirectionControl ThrusterDirectionControl, tN2kGenericStatusPair PowerEnable, tN2kThrusterRetraction ThrusterRetractControl, unsigned char SpeedControl, tN2kThrusterControlEvents ThrusterControlEvents, double CommandTimeout, double AzimuthControl) {
     N2kMsg.SetPGN(128006L);
-    N2kMsg.Priority=4;
+    N2kMsg.Priority = 2;
     N2kMsg.AddByte(SID);
     N2kMsg.AddByte(ThrusterId);
     N2kMsg.AddByte((unsigned char) ((ThrusterRetractControl & 0x03) << 6) | ((PowerEnable & 0x03) << 4) | (ThrusterDirectionControl & 0x0f)); 
@@ -630,7 +630,7 @@ bool parseN2kPGN128006(const tN2kMsg &N2kMsg, unsigned char &SID, unsigned char 
 
 void SetN2kPGN128007(tN2kMsg &N2kMsg, unsigned char ThrusterId, tN2kMotorPowerType ThrusterMotorType, uint16_t MotorPowerRating, uint16_t MaximumMotorTemperatureRating, uint16_t MaximumRotationalSpeed) {
     N2kMsg.SetPGN(128006L);
-    N2kMsg.Priority=4;
+    N2kMsg.Priority = 7;
     N2kMsg.AddByte(ThrusterId);
     N2kMsg.AddByte((unsigned char) (0xf0 | (ThrusterMotorType & 0x04)));
     N2kMsg.Add2ByteUInt(MotorPowerRating);
@@ -655,7 +655,7 @@ bool parseN2kPGN128007(const tN2kMsg &N2kMsg, unsigned char &ThrusterId, tN2kMot
 
 void setN2kPGN128008(tN2kMsg &N2kMsg, unsigned char SID, unsigned char ThrusterId, tN2kThrusterMotorEvents ThrusterMotorEvents, unsigned char MotorCurrent, double MotorTemperature, uint16_t TotalMotorOperatingTime) {
     N2kMsg.SetPGN(128008L);
-    N2kMsg.Priority=4;
+    N2kMsg.Priority = 2;
     N2kMsg.AddByte(SID);
     N2kMsg.AddByte(ThrusterId);
     N2kMsg.AddByte(ThrusterMotorEvents.Events);

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -594,6 +594,89 @@ bool ParseN2kPGN128000(const tN2kMsg &N2kMsg, unsigned char &SID, double &Leeway
 }
 
 //*****************************************************************************
+// Thruster Control Status (PGN 128006)
+
+void SetN2kPGN128006(tN2kMsg &N2kMsg, unsigned char SID, unsigned char ThrusterId, tN2kThrusterDirectionControl ThrusterDirectionControl, tN2kGenericStatusPair PowerEnable, tN2kThrusterRetraction ThrusterRetractControl, unsigned char SpeedControl, tN2kThrusterControlEvents ThrusterControlEvents, double CommandTimeout, double AzimuthControl) {
+    N2kMsg.SetPGN(128006L);
+    N2kMsg.Priority=4;
+    N2kMsg.AddByte(SID);
+    N2kMsg.AddByte(ThrusterId);
+    N2kMsg.AddByte((unsigned char) ((ThrusterRetractControl & 0x03) << 6) | ((PowerEnable & 0x03) << 4) | (ThrusterDirectionControl & 0x0f)); 
+    N2kMsg.AddByte((SpeedControl > 100)?100:0);
+    N2kMsg.AddByte(ThrusterControlEvents.Events);
+    N2kMsg.Add1ByteUDouble(CommandTimeout, 0.005);
+    N2kMsg.Add2ByteDouble(AzimuthControl, 0.0001);
+}
+
+bool parseN2kPGN128006(const tN2kMsg &N2kMsg, unsigned char &SID, unsigned char &ThrusterId, tN2kThrusterDirectionControl &ThrusterDirectionControl, tN2kGenericStatusPair &PowerEnable, tN2kThrusterRetraction &ThrusterRetractControl, unsigned char &SpeedControl, tN2kThrusterControlEvents &ThrusterControlEvents, double &CommandTimeout, double &AzimuthControl) {
+    if (N2kMsg.PGN != 128006UL) return false;
+    int Index = 0;
+    SID = N2kMsg.GetByte(Index);
+    ThrusterId = N2kMsg.GetByte(Index);
+    unsigned char pack = N2kMsg.GetByte(Index);
+    ThrusterDirectionControl = (tN2kThrusterDirectionControl) (pack & 0x04);
+    PowerEnable = (tN2kGenericStatusPair) ((pack >> 4) & 0x02);
+    ThrusterRetractControl = (tN2kThrusterRetraction) ((pack >> 6) & 0x02);
+    SpeedControl = N2kMsg.GetByte(Index);
+    ThrusterControlEvents.SetEvents(N2kMsg.GetByte(Index));
+    CommandTimeout = N2kMsg.Get1ByteUDouble(0.005, Index);
+    AzimuthControl = N2kMsg.Get2ByteDouble(0.0001, Index);
+    return true;
+}
+
+
+//*****************************************************************************
+// Thruster Information (PGN 128007)
+
+void SetN2kPGN128007(tN2kMsg &N2kMsg, unsigned char ThrusterId, tN2kMotorPowerType ThrusterMotorType, uint16_t MotorPowerRating, uint16_t MaximumMotorTemperatureRating, uint16_t MaximumRotationalSpeed) {
+    N2kMsg.SetPGN(128006L);
+    N2kMsg.Priority=4;
+    N2kMsg.AddByte(ThrusterId);
+    N2kMsg.AddByte((unsigned char) (0xf0 | (ThrusterMotorType & 0x04)));
+    N2kMsg.Add2ByteUInt(MotorPowerRating);
+    N2kMsg.Add2ByteUDouble(MaximumMotorTemperatureRating, 0.01);
+    N2kMsg.Add2ByteUDouble(MaximumRotationalSpeed, 0.25);
+}
+
+bool parseN2kPGN128007(const tN2kMsg &N2kMsg, unsigned char &ThrusterId, tN2kMotorPowerType &ThrusterMotorType, uint16_t &MotorPowerRating, uint16_t &MaximumMotorTemperatureRating, uint16_t &MaximumRotationalSpeed) {
+    if (N2kMsg.PGN != 128007UL) return false;
+    int Index = 0;
+    ThrusterId = N2kMsg.GetByte(Index);
+    unsigned char pack = N2kMsg.GetByte(Index);
+    ThrusterMotorType = (tN2kMotorPowerType) (pack & 0x04);
+    MotorPowerRating = N2kMsg.Get2ByteUInt(Index);
+    MaximumMotorTemperatureRating = N2kMsg.Get2ByteUDouble(0.01, Index);
+    MaximumRotationalSpeed = N2kMsg.Get2ByteUDouble(0.25, Index);
+    return true;
+}
+
+//*****************************************************************************
+// Thruster Motor Status (PGN 128008)
+
+void setN2kPGN128008(tN2kMsg &N2kMsg, unsigned char SID, unsigned char ThrusterId, tN2kThrusterMotorEvents ThrusterMotorEvents, unsigned char MotorCurrent, double MotorTemperature, uint16_t TotalMotorOperatingTime) {
+    N2kMsg.SetPGN(128008L);
+    N2kMsg.Priority=4;
+    N2kMsg.AddByte(SID);
+    N2kMsg.AddByte(ThrusterId);
+    N2kMsg.AddByte(ThrusterMotorEvents.Events);
+    N2kMsg.AddByte((MotorCurrent > 252)?252:MotorCurrent);
+    N2kMsg.Add2ByteUDouble(MotorTemperature, 0.01);
+    N2kMsg.Add2ByteUInt(TotalMotorOperatingTime);
+}
+
+bool parseN2kPGN128008(const tN2kMsg &N2kMsg, unsigned char &SID, unsigned char &ThrusterId, tN2kThrusterMotorEvents &ThrusterMotorEvents, unsigned char &MotorCurrent, double &MotorTemperature, uint16_t &TotalMotorOperatingTime) {
+    if (N2kMsg.PGN != 128008UL) return false;
+    int Index = 0;
+    SID = N2kMsg.GetByte(Index);
+    ThrusterId = N2kMsg.GetByte(Index);
+    ThrusterMotorEvents.SetEvents(N2kMsg.GetByte(Index));
+    MotorCurrent = N2kMsg.GetByte(Index);
+    MotorTemperature = N2kMsg.Get2ByteUDouble(0.01, Index);
+    TotalMotorOperatingTime = N2kMsg.Get2ByteUInt(Index);
+    return true;
+}
+
+//*****************************************************************************
 // Boat speed
 void SetN2kPGN128259(tN2kMsg &N2kMsg, unsigned char SID, double WaterReferenced, double GroundReferenced, tN2kSpeedWaterReferenceType SWRT) {
     N2kMsg.SetPGN(128259L);

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -653,7 +653,7 @@ bool parseN2kPGN128007(const tN2kMsg &N2kMsg, unsigned char &ThrusterId, tN2kMot
 //*****************************************************************************
 // Thruster Motor Status (PGN 128008)
 
-void setN2kPGN128008(tN2kMsg &N2kMsg, unsigned char SID, unsigned char ThrusterId, tN2kThrusterMotorEvents ThrusterMotorEvents, unsigned char MotorCurrent, double MotorTemperature, uint16_t TotalMotorOperatingTime) {
+void SetN2kPGN128008(tN2kMsg &N2kMsg, unsigned char SID, unsigned char ThrusterId, tN2kThrusterMotorEvents ThrusterMotorEvents, unsigned char MotorCurrent, double MotorTemperature, uint16_t TotalMotorOperatingTime) {
     N2kMsg.SetPGN(128008L);
     N2kMsg.Priority = 2;
     N2kMsg.AddByte(SID);
@@ -664,7 +664,7 @@ void setN2kPGN128008(tN2kMsg &N2kMsg, unsigned char SID, unsigned char ThrusterI
     N2kMsg.Add2ByteUInt(TotalMotorOperatingTime);
 }
 
-bool parseN2kPGN128008(const tN2kMsg &N2kMsg, unsigned char &SID, unsigned char &ThrusterId, tN2kThrusterMotorEvents &ThrusterMotorEvents, unsigned char &MotorCurrent, double &MotorTemperature, uint16_t &TotalMotorOperatingTime) {
+bool ParseN2kPGN128008(const tN2kMsg &N2kMsg, unsigned char &SID, unsigned char &ThrusterId, tN2kThrusterMotorEvents &ThrusterMotorEvents, unsigned char &MotorCurrent, double &MotorTemperature, uint16_t &TotalMotorOperatingTime) {
     if (N2kMsg.PGN != 128008UL) return false;
     int Index = 0;
     SID = N2kMsg.GetByte(Index);

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -684,6 +684,99 @@ inline bool ParseN2kLeeway(const tN2kMsg &N2kMsg, unsigned char &SID, double &Le
 }
 
 //*****************************************************************************
+// Thruster Control Status
+//  - SID - sequence ID
+//  - ThrusterId - thruster ID in range 0..255
+//  - ThrusterDirectionControl - which way the thruster is operating
+//  - PowerEnable - whether the thruster is enabled or disabled
+//  - ThrusterRetractControl - whether the thruster is retracted or deployed
+//  - SpeedControl - thruster speed in range 0..100
+//  - ThrusterControlEvents - current control errors (0 says none)
+//  - CommandTimeout - in the range 0..1.25s
+//  - AzimuthControl - in radians relative to bow, +ve starboard, -ve port
+
+void SetN2kPGN128006(
+  tN2kMsg &N2kMsg,
+  unsigned char SID,
+  unsigned char ThrusterId,
+  tN2kThrusterDirectionControl ThrusterDirectionControl,
+  tN2kGenericStatusPair PowerEnable,
+  tN2kThrusterRetraction ThrusterRetractControl,
+  unsigned char SpeedControl,
+  tN2kThrusterControlEvents ThrusterControlEvents,
+  double CommandTimeout,
+  double AzimuthControl
+);
+
+bool parseN2kPGN128006(
+  const tN2kMsg &N2kMsg,
+  unsigned char &SID,
+  unsigned char &ThrusterId,
+  tN2kThrusterDirectionControl &ThrusterDirectionControl,
+  tN2kGenericStatusPair &PowerEnable,
+  tN2kThrusterRetraction &ThrusterRetractControl,
+  unsigned char &SpeedControl,
+  tN2kThrusterControlEvents &ThrusterControlEvents,
+  double &CommandTimeout,
+  double &AzimuthControl
+);
+
+//*****************************************************************************
+// Thruster Information
+//  - ThrusterID
+//  - ThrusterMotorType
+//  - MotorPowerRating
+//  - MaximumMotorTemperatureRating
+//  - MaximumRotationalSpeed
+
+void SetN2kPGN128007(
+  tN2kMsg &N2kMsg,
+  unsigned char ThrusterId,
+  tN2kMotorPowerType ThrusterMotorType,
+  uint16_t MotorPowerRating,
+  uint16_t MaximumMotorTemperatureRating,
+  uint16_t MaximumRotationalSpeed
+);
+
+bool parseN2kPGN128007(
+  const tN2kMsg &N2kMsg,
+  unsigned char &ThrusterId,
+  tN2kMotorPowerType &ThrusterMotorType,
+  uint16_t &MotorPowerRating,
+  uint16_t &MaximumMotorTemperatureRating,
+  uint16_t &MaximumRotationalSpeed
+);
+
+//*****************************************************************************
+// Thruster Motor Status
+//  - SID
+//  - Thruster ID - 0..255
+//  - ThrusterMotorEvents - see tN2kThrusterMotorEvents
+//  - MotorCurrent - 0..252 Amps
+//  - MotorTemperature - 0..655.32 degrees Kelvin
+//  - TotalMotorOperatingTime - 0..65536 minutes
+
+void setN2kPGN128008(
+  tN2kMsg &N2kMsg,
+  unsigned char SID,
+  unsigned char ThrusterId,
+  tN2kThrusterMotorEvents ThrusterMotorEvents,
+  unsigned char MotorCurrent,
+  double MotorTemperature,
+  uint16_t TotalMotorOperatingTime
+);
+
+bool parseN2kPGN128008(
+  const tN2kMsg &N2kMsg,
+  unsigned char &SID,
+  unsigned char &ThrusterId,
+  tN2kThrusterMotorEvents &ThrusterMotorEvents,
+  unsigned char &MotorCurrent,
+  double &MotorTemperature,
+  uint16_t &TotalMotorOperatingTime
+);
+
+//*****************************************************************************
 // Boat speed
 // Input:
 //  - SID                   Sequence ID. If your device is e.g. boat speed and wind at same time, you can set same SID for different messages

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -72,7 +72,6 @@ void SetN2kPGN126992(tN2kMsg &N2kMsg, unsigned char SID, uint16_t SystemDate,
 
 inline void SetN2kSystemTime(tN2kMsg &N2kMsg, unsigned char SID, uint16_t SystemDate,
                      double SystemTime, tN2kTimeSource TimeSource=N2ktimes_GPS) {
-  SetN2kPGN126992(N2kMsg,SID,SystemDate,SystemTime,TimeSource);
 }
 
 bool ParseN2kPGN126992(const tN2kMsg &N2kMsg, unsigned char &SID, uint16_t &SystemDate,
@@ -756,7 +755,7 @@ bool parseN2kPGN128007(
 //  - MotorTemperature - 0..655.32 degrees Kelvin
 //  - TotalMotorOperatingTime - 0..65536 minutes
 
-void setN2kPGN128008(
+void SetN2kPGN128008(
   tN2kMsg &N2kMsg,
   unsigned char SID,
   unsigned char ThrusterId,
@@ -766,7 +765,7 @@ void setN2kPGN128008(
   uint16_t TotalMotorOperatingTime
 );
 
-bool parseN2kPGN128008(
+bool ParseN2kPGN128008(
   const tN2kMsg &N2kMsg,
   unsigned char &SID,
   unsigned char &ThrusterId,

--- a/src/N2kTypes.h
+++ b/src/N2kTypes.h
@@ -365,6 +365,30 @@ using tN2kPRNUsageStatus = tN2kDD124;
                   // N2kDD124_Error=14,
                   // N2kDD124_Unavailable=15,
 
+using tN2kThrusterMotorEvents = tN2kDD471;
+	// .Event.MotorOverTemperatureCutout = 0 | 1
+	// .Event.MotorOverCurrentCutout = 0 | 1
+	// .Event.LowOilLevelWarning = 0 | 1
+	// .Event.OilOverTemperatureWarning = 0 | 1
+	// .Event.ControllerUnderVoltageCutout = 0 | 1
+	// .Event.ManufacturerDefined = 0 | 1
+	// .Event.DataNotAvailable = 0 | 1
+
+using tN2kThrusterDirectionControl = tN2kDD473;
+	// N2kDD473_OFF=0
+	// N2kDD473_ThrusterReady=1
+	// N2kDD473_ThrusterToPORT=2
+	// N2kDD473_ThrusterToSTARBOARD=3
+
+using tN2kThrusterRetraction = tN2kDD474;
+	// N2kDD474_OFF=0
+	// N2kDD474_Extend=1
+	// N2kDD474_Retract=2
+
+using tN2kThrusterControlEvents = tN2kDD475;
+	// .Event.AnotherDeviceControllingThruster = 0 | 1
+	// .Event.BoatSpeedTooFast = 0 | 1
+
 using tN2kWindlassMonitoringEvents = tN2kDD477;
 			    // Union type with fields:
                             // .Event.ControllerUnderVoltageCutout = 0 | 1
@@ -412,6 +436,13 @@ using tN2kWindlassDirectionControl = tN2kDD484;
                             // N2kDD484_Down=1
                             // N2kDD484_Up=2
                             // N2kDD484_Reserved=3
+
+using tN2kMotorPowerType = tN2kDD487;
+	// N2kDD487_12VDC=0
+	// N2kDD487_24VDC=1
+	// N2kDD487_48VDC=2
+	// N2kDD487_12VAC=3
+	// N2kDD487_Hydraulic=4
 
 using tN2kSpeedType = tN2kDD488;
 			    // Enum type members:

--- a/src/NMEA2000StdTypes.h
+++ b/src/NMEA2000StdTypes.h
@@ -76,29 +76,6 @@ enum tN2kDD124 {
                   N2kDD124_Error=14,
                   N2kDD124_Unavailable=15,
                 };
-// DD477 - Windlass Monitoring Events
-//
-union tN2kDD477 {
-          unsigned char Events;
-          struct {
-            unsigned char ControllerUnderVoltageCutout:1;
-            unsigned char ControllerOverCurrentCutout:1;
-            unsigned char ControllerOverTemperatureCutout:1;
-          } Event;
-          tN2kDD477(): Events(0) {};
-          void SetEvents(unsigned char _Events) { Events = (_Events & 0x07); }
-        };
-
-// DD478 - Windlass Control Events
-//
-union tN2kDD478 {
-          unsigned char Events;
-          struct {
-            unsigned char AnotherDeviceControllingWindlass:1;
-          } Event;
-          tN2kDD478(): Events(0) {};
-          void SetEvents(unsigned char _Events) { Events = (_Events & 0x01); }
-        };
 
 union tN2kDD206 {
           uint16_t Status;
@@ -138,6 +115,78 @@ union tN2kDD223 {
           tN2kDD223(uint16_t _Status=0): Status(_Status & 0x00ff) {};
           uint16_t operator= (uint16_t val) { Status=val & 0x00ff; return Status;}
 };
+
+// Thruster Motor Events
+//
+union tN2kDD471 {
+	unsigned char Events;
+	struct {
+		unsigned char MotorOverTemperatureCutout:1;
+		unsigned char MotorOverCurrentCutout:1;
+		unsigned char LowOilLevelWarning:1;
+		unsigned char OilOverTemperatureWarning:1;
+		unsigned char ControllerUnderVoltageCutout:1;
+		unsigned char ManufacturerDefined:1;
+		unsigned char Reserved:1;
+		unsigned char DataNotAvailable:1;
+	} Event;
+	tN2kDD471(): Events(0) {};
+	void SetEvents(unsigned char _Events) { Events = (_Events & 0xbf); }
+};
+
+// Thruster Direction Control
+//
+enum tN2kDD473 {
+	N2kDD473_OFF=0,
+	N2kDD473_ThrusterReady=1,
+	N2kDD473_ThrusterToPORT=2,
+	N2kDD473_ThrusterToSTARBOARD=3
+};
+
+// Thruster Retraction
+//
+enum tN2kDD474 {
+	N2kDD474_OFF=0,
+	N2kDD474_Extend=1,
+	N2kDD474_Retract=2
+};
+
+// Thruster Control Events
+//
+union tN2kDD475 {
+	unsigned char Events;
+	struct {
+		unsigned char AnotherDeviceControllingThruster:1;
+		unsigned char BoatSpeedTooFast:1;
+	} Event;
+	tN2kDD475(): Events(0) {};
+	void SetEvents(unsigned char _Events) { Events = (_Events & 0x03); }
+};
+
+// DD477 - Windlass Monitoring Events
+//
+union tN2kDD477 {
+          unsigned char Events;
+          struct {
+            unsigned char ControllerUnderVoltageCutout:1;
+            unsigned char ControllerOverCurrentCutout:1;
+            unsigned char ControllerOverTemperatureCutout:1;
+          } Event;
+          tN2kDD477(): Events(0) {};
+          void SetEvents(unsigned char _Events) { Events = (_Events & 0x07); }
+        };
+
+// DD478 - Windlass Control Events
+//
+union tN2kDD478 {
+          unsigned char Events;
+          struct {
+            unsigned char AnotherDeviceControllingWindlass:1;
+          } Event;
+          tN2kDD478(): Events(0) {};
+          void SetEvents(unsigned char _Events) { Events = (_Events & 0x01); }
+        };
+
 
 // DD480 - Windlass Motion States
 //                          
@@ -189,6 +238,16 @@ enum tN2kDD484 {
                             N2kDD484_Up=2,
                             N2kDD484_Reserved=3
                           };
+
+// DD487 - Motor Power Type
+//
+enum tN2kDD487 {
+	N2kDD487_12VDC=0,
+	N2kDD487_24VDC=1,
+	N2kDD487_48VDC=2,
+	N2kDD487_24VAC=3,
+	N2kDD487_Hydraulic=4,
+};
 
 // DD488 - Speed Type
 //          


### PR DESCRIPTION
Hello again Timo. Hope you are well.

I wonder if you would be interested in merging these changes which respond to https://www.nmea.org/Assets/20190613%20thruster%20amendment%20128006,%20128007,%20128008.pdf.

* add PGN 128006 Thruster Control Status
* add PGN 128007 Thruster Information
* add PGN 128008 Thruster Motor Status
* add tN2kDD471 and the alias tN2kThrusterMotorEvents
* add tN2kDD473 and the alias tN2kDirectionControl
* add tN2kDD474 and the alias tN2kThrusterRetraction
* add tN2kDD475 and the alias tN2kThrusterControlEvents
* add tN2kDD487 and the alias tN2kMotorPowerType

Paul
