### PR TITLE
Add support for PGN 130323 (Meteorlogical Station Data)

### DIFF
--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -23,7 +23,6 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "N2kMessages.h"
 #include <string.h>
-#include <iostream>
 
 //*****************************************************************************
 // System time

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -1905,8 +1905,7 @@ void SetN2kPGN130323(tN2kMsg &N2kMsg, const tN2kMeteorlogicalStationData &N2kDat
 }
 
 
-bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, tN2kMeteorlogicalStationData &N2kData,
-                        size_t StationIDMaxSize, size_t StationNameMaxSize) {
+bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, tN2kMeteorlogicalStationData &N2kData) {
     if (N2kMsg.PGN!=130323L) return false;
     int Index=0;
     unsigned char vb;
@@ -1924,8 +1923,10 @@ bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, tN2kMeteorlogicalStationData &N2kD
     N2kData.WindGusts = N2kMsg.Get2ByteUDouble(0.01,Index);
     N2kData.AtmosphericPressure = N2kMsg.Get2ByteUDouble(100,Index);
     N2kData.OutsideAmbientAirTemperature=N2kMsg.Get2ByteUDouble(0.01,Index);
-    N2kMsg.GetVarStr(StationIDMaxSize, (char*)N2kData.StationID, Index);
-    N2kMsg.GetVarStr(StationNameMaxSize, (char*)N2kData.StationName, Index);
+    size_t StationIDSize = sizeof(N2kData.StationID);
+    size_t StationNameSize = sizeof(N2kData.StationName);
+    N2kMsg.GetVarStr(StationIDSize, (char*)N2kData.StationID, Index);
+    N2kMsg.GetVarStr(StationNameSize, (char*)N2kData.StationName, Index);
 
     return true;
 }

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -21,7 +21,6 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <iostream>
 #include "N2kMessages.h"
 #include <string.h>
 

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -21,6 +21,7 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include <iostream>
 #include "N2kMessages.h"
 #include <string.h>
 
@@ -1882,6 +1883,54 @@ bool ParseN2kPGN130316(const tN2kMsg &N2kMsg, unsigned char &SID, unsigned char 
   SetTemperature=N2kMsg.Get2ByteDouble(0.1,Index);
 
   return true;
+}
+
+//*****************************************************************************
+// Meteorological Station Data
+void SetN2kPGN130323(tN2kMsg &N2kMsg, uint16_t SystemDate, double SystemTime, double Latitude, double Longitude,
+                      double WindSpeed, double WindAngle, tN2kWindReference WindReference, double WindGusts, 
+                      char *StationID, char* StationName, double AtmosphericPressure, 
+                      double OutsideAmbientAirTemperature) {
+    N2kMsg.SetPGN(130323L);
+    N2kMsg.Priority=5;
+    N2kMsg.AddByte(0x00);
+    N2kMsg.Add2ByteUInt(SystemDate);
+    N2kMsg.Add4ByteUDouble(SystemTime,0.0001);
+    N2kMsg.Add4ByteDouble(Latitude,1e-7);
+    N2kMsg.Add4ByteDouble(Longitude,1e-7);
+    N2kMsg.Add2ByteUDouble(WindSpeed,0.01);
+    N2kMsg.Add2ByteUDouble(WindAngle,0.01);
+    N2kMsg.AddByte((unsigned char)WindReference);
+    N2kMsg.Add2ByteUDouble(WindGusts,0.01);
+    N2kMsg.Add2ByteUDouble(AtmosphericPressure,100);
+    N2kMsg.Add2ByteUDouble(OutsideAmbientAirTemperature,0.01);
+    N2kMsg.AddVarStr(StationID);
+    N2kMsg.AddVarStr(StationName);
+}
+
+
+bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, uint16_t &SystemDate, double &SystemTime, double &Latitude, double &Longitude,
+                      double &WindSpeed, double &WindAngle, tN2kWindReference &WindReference, double &WindGusts, 
+                      char *StationID, size_t StationIDMaxSize, char* StationName, size_t StationNameMaxSize,
+                      double &AtmosphericPressure, double &OutsideAmbientAirTemperature) {
+    if (N2kMsg.PGN!=130323L) return false;
+
+    int Index=0;
+    N2kMsg.GetByte(Index);  // reserved
+    SystemDate = N2kMsg.Get2ByteUInt(Index);
+    SystemTime = N2kMsg.Get4ByteUDouble(0.0001,Index);
+    Latitude = N2kMsg.Get4ByteDouble(1e-7,Index);
+    Longitude = N2kMsg.Get4ByteDouble(1e-7,Index);
+    WindSpeed = N2kMsg.Get2ByteUDouble(0.01,Index);
+    WindAngle = N2kMsg.Get2ByteUDouble(0.01,Index);
+    WindReference = (tN2kWindReference)(N2kMsg.GetByte(Index)&0x07);
+    WindGusts = N2kMsg.Get2ByteUDouble(0.01,Index);
+    AtmosphericPressure = N2kMsg.Get2ByteUDouble(100,Index);
+    OutsideAmbientAirTemperature=N2kMsg.Get2ByteUDouble(0.01,Index);
+    N2kMsg.GetVarStr(StationIDMaxSize, StationID, Index);
+    N2kMsg.GetVarStr(StationNameMaxSize, StationName, Index);
+
+    return true;
 }
 
 //*****************************************************************************

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -23,6 +23,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "N2kMessages.h"
 #include <string.h>
+#include <iostream>
 
 //*****************************************************************************
 // System time
@@ -1886,51 +1887,47 @@ bool ParseN2kPGN130316(const tN2kMsg &N2kMsg, unsigned char &SID, unsigned char 
 
 //*****************************************************************************
 // Meteorological Station Data
-void SetN2kPGN130323(tN2kMsg &N2kMsg, tN2kAISMode Mode, uint16_t SystemDate, double SystemTime, double Latitude, double Longitude,
-                      double WindSpeed, double WindDirection, tN2kWindReference WindReference, double WindGusts, 
-                      const char *StationID, const char* StationName, double AtmosphericPressure, 
-                      double OutsideAmbientAirTemperature) {
+void SetN2kPGN130323(tN2kMsg &N2kMsg, const tN2kMeteorlogicalStationData N2kData) {
     N2kMsg.SetPGN(130323L);
     N2kMsg.Priority=6;
-    N2kMsg.AddByte( ((((unsigned char) Mode) & 0x0f) << 4) | 0x0f );
-    N2kMsg.Add2ByteUInt(SystemDate);
-    N2kMsg.Add4ByteUDouble(SystemTime,0.0001);
-    N2kMsg.Add4ByteDouble(Latitude,1e-7);
-    N2kMsg.Add4ByteDouble(Longitude,1e-7);
-    N2kMsg.Add2ByteUDouble(WindSpeed,0.01);
-    N2kMsg.Add2ByteUDouble(WindDirection,0.0001);
-    N2kMsg.AddByte( ((((unsigned char)WindReference) & 0x07) << 5) | 0x1f );
-    N2kMsg.Add2ByteUDouble(WindGusts,0.01);
-    N2kMsg.Add2ByteUDouble(AtmosphericPressure,100);
-    N2kMsg.Add2ByteUDouble(OutsideAmbientAirTemperature,0.01);
-    N2kMsg.AddVarStr(StationID);
-    N2kMsg.AddVarStr(StationName);
+    N2kMsg.AddByte( ((((unsigned char) N2kData.Mode) & 0x0f) << 4) | 0x0f );
+    N2kMsg.Add2ByteUInt(N2kData.SystemDate);
+    N2kMsg.Add4ByteUDouble(N2kData.SystemTime,0.0001);
+    N2kMsg.Add4ByteDouble(N2kData.Latitude,1e-7);
+    N2kMsg.Add4ByteDouble(N2kData.Longitude,1e-7);
+    N2kMsg.Add2ByteUDouble(N2kData.WindSpeed,0.01);
+    N2kMsg.Add2ByteUDouble(N2kData.WindDirection,0.0001);
+    N2kMsg.AddByte( ((((unsigned char)N2kData.WindReference) & 0x07) << 5) | 0x1f );
+    N2kMsg.Add2ByteUDouble(N2kData.WindGusts,0.01);
+    N2kMsg.Add2ByteUDouble(N2kData.AtmosphericPressure,100);
+    N2kMsg.Add2ByteUDouble(N2kData.OutsideAmbientAirTemperature,0.01);
+    N2kMsg.AddVarStr((char*)N2kData.StationID);
+    N2kMsg.AddVarStr((char*)N2kData.StationName);
 }
 
 
-bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, tN2kAISMode &Mode, uint16_t &SystemDate, double &SystemTime, double &Latitude, 
-                      double &Longitude, double &WindSpeed, double &WindDirection, tN2kWindReference &WindReference,
-                      double &WindGusts, char *StationID, size_t StationIDMaxSize, char* StationName, size_t StationNameMaxSize, 
-                      double &AtmosphericPressure, double &OutsideAmbientAirTemperature) {
+bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, tN2kMeteorlogicalStationData &N2kData,
+                        size_t StationIDMaxSize, size_t StationNameMaxSize) {
     if (N2kMsg.PGN!=130323L) return false;
     int Index=0;
     unsigned char vb;
 
     vb = N2kMsg.GetByte(Index);
-    Mode=(tN2kAISMode)((vb >> 4) & 0x0f);
-    SystemDate = N2kMsg.Get2ByteUInt(Index);
-    SystemTime = N2kMsg.Get4ByteUDouble(0.0001,Index);
-    Latitude = N2kMsg.Get4ByteDouble(1e-7,Index);
-    Longitude = N2kMsg.Get4ByteDouble(1e-7,Index);
-    WindSpeed = N2kMsg.Get2ByteUDouble(0.01,Index);
-    WindDirection = N2kMsg.Get2ByteUDouble(0.0001,Index);
+    N2kData.Mode=(tN2kAISMode)((vb >> 4) & 0x0f);
+
+    N2kData.SystemDate = N2kMsg.Get2ByteUInt(Index);
+    N2kData.SystemTime = N2kMsg.Get4ByteUDouble(0.0001,Index);
+    N2kData.Latitude = N2kMsg.Get4ByteDouble(1e-7,Index);
+    N2kData.Longitude = N2kMsg.Get4ByteDouble(1e-7,Index);
+    N2kData.WindSpeed = N2kMsg.Get2ByteUDouble(0.01,Index);
+    N2kData.WindDirection = N2kMsg.Get2ByteUDouble(0.0001,Index);
     vb = N2kMsg.GetByte(Index);
-    WindReference = (tN2kWindReference)((vb >> 5) & 0x07);
-    WindGusts = N2kMsg.Get2ByteUDouble(0.01,Index);
-    AtmosphericPressure = N2kMsg.Get2ByteUDouble(100,Index);
-    OutsideAmbientAirTemperature=N2kMsg.Get2ByteUDouble(0.01,Index);
-    N2kMsg.GetVarStr(StationIDMaxSize, StationID, Index);
-    N2kMsg.GetVarStr(StationNameMaxSize, StationName, Index);
+    N2kData.WindReference = (tN2kWindReference)((vb >> 5) & 0x07);
+    N2kData.WindGusts = N2kMsg.Get2ByteUDouble(0.01,Index);
+    N2kData.AtmosphericPressure = N2kMsg.Get2ByteUDouble(100,Index);
+    N2kData.OutsideAmbientAirTemperature=N2kMsg.Get2ByteUDouble(0.01,Index);
+    N2kMsg.GetVarStr(StationIDMaxSize, (char*)N2kData.StationID, Index);
+    N2kMsg.GetVarStr(StationNameMaxSize, (char*)N2kData.StationName, Index);
 
     return true;
 }

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -1886,17 +1886,17 @@ bool ParseN2kPGN130316(const tN2kMsg &N2kMsg, unsigned char &SID, unsigned char 
 
 //*****************************************************************************
 // Meteorological Station Data
-void SetN2kPGN130323(tN2kMsg &N2kMsg, const tN2kMeteorlogicalStationData N2kData) {
+void SetN2kPGN130323(tN2kMsg &N2kMsg, const tN2kMeteorlogicalStationData &N2kData) {
     N2kMsg.SetPGN(130323L);
     N2kMsg.Priority=6;
-    N2kMsg.AddByte( ((((unsigned char) N2kData.Mode) & 0x0f) << 4) | 0x0f );
+    N2kMsg.AddByte( (((unsigned char) N2kData.Mode) & 0x0f) | 0xf0 );
     N2kMsg.Add2ByteUInt(N2kData.SystemDate);
     N2kMsg.Add4ByteUDouble(N2kData.SystemTime,0.0001);
     N2kMsg.Add4ByteDouble(N2kData.Latitude,1e-7);
     N2kMsg.Add4ByteDouble(N2kData.Longitude,1e-7);
     N2kMsg.Add2ByteUDouble(N2kData.WindSpeed,0.01);
     N2kMsg.Add2ByteUDouble(N2kData.WindDirection,0.0001);
-    N2kMsg.AddByte( ((((unsigned char)N2kData.WindReference) & 0x07) << 5) | 0x1f );
+    N2kMsg.AddByte( (((unsigned char)N2kData.WindReference) & 0x07) | 0xf8 );
     N2kMsg.Add2ByteUDouble(N2kData.WindGusts,0.01);
     N2kMsg.Add2ByteUDouble(N2kData.AtmosphericPressure,100);
     N2kMsg.Add2ByteUDouble(N2kData.OutsideAmbientAirTemperature,0.01);
@@ -1912,8 +1912,7 @@ bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, tN2kMeteorlogicalStationData &N2kD
     unsigned char vb;
 
     vb = N2kMsg.GetByte(Index);
-    N2kData.Mode=(tN2kAISMode)((vb >> 4) & 0x0f);
-
+    N2kData.Mode=(tN2kAISMode)(vb & 0x0f);
     N2kData.SystemDate = N2kMsg.Get2ByteUInt(Index);
     N2kData.SystemTime = N2kMsg.Get4ByteUDouble(0.0001,Index);
     N2kData.Latitude = N2kMsg.Get4ByteDouble(1e-7,Index);
@@ -1921,7 +1920,7 @@ bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, tN2kMeteorlogicalStationData &N2kD
     N2kData.WindSpeed = N2kMsg.Get2ByteUDouble(0.01,Index);
     N2kData.WindDirection = N2kMsg.Get2ByteUDouble(0.0001,Index);
     vb = N2kMsg.GetByte(Index);
-    N2kData.WindReference = (tN2kWindReference)((vb >> 5) & 0x07);
+    N2kData.WindReference = (tN2kWindReference)(vb & 0x07);
     N2kData.WindGusts = N2kMsg.Get2ByteUDouble(0.01,Index);
     N2kData.AtmosphericPressure = N2kMsg.Get2ByteUDouble(100,Index);
     N2kData.OutsideAmbientAirTemperature=N2kMsg.Get2ByteUDouble(0.01,Index);

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -1824,8 +1824,8 @@ inline bool ParseN2kTemperatureExt(const tN2kMsg &N2kMsg, unsigned char &SID, un
 //  - WindGusts             Measured wind gusts speed in m/s
 //  - AtmosphericPressure   Atmospheric pressure in Pascals. Use function mBarToPascal, if you like to use mBar
 //  - OutsideAmbientAirTemperature      Outside ambient temperature in K. Use function CToKelvin, if you want to use °C.
-//  - StationID             //TODO What is this?
-//  - StationName           //TODO What is this?
+//  - StationID             Identifier of the transmitting weather station. (255 bytes max)
+//  - StationName           Friendly name of the transmitting weather station. (255 bytes max)
 //  
 //
 // Output:

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -1810,6 +1810,54 @@ inline bool ParseN2kTemperatureExt(const tN2kMsg &N2kMsg, unsigned char &SID, un
   return ParseN2kPGN130316(N2kMsg, SID, TempInstance, TempSource, ActualTemperature, SetTemperature);
 }
 
+//*****************************************************************************
+// Meteorlogical Station Data
+// Input:
+//  - SID                   Sequence ID.
+//  - SystemDate            Days since 1970-01-01
+//  - SystemTime            seconds since midnight
+//  - Latitude              The latitude of the current waypoint
+//  - Longitude             The longitude of the current waypoint
+//  - WindSpeed             Measured wind speed in m/s
+//  - WindAngle             Measured wind angle in radians. If you have value in degrees, use function DegToRad(myval) in call.
+//  - WindReference         Wind reference, see definition of tN2kWindReference
+//  - WindGusts             Measured wind gusts speed in m/s
+//  - AtmosphericPressure   Atmospheric pressure in Pascals. Use function mBarToPascal, if you like to use mBar
+//  - OutsideAmbientAirTemperature      Outside ambient temperature in K. Use function CToKelvin, if you want to use °C.
+//  - StationID             //TODO What is this?
+//  - StationName           //TODO What is this?
+//  
+//
+// Output:
+//  - N2kMsg                NMEA2000 message ready to be send.
+void SetN2kPGN130323(tN2kMsg &N2kMsg, uint16_t SystemDate, double SystemTime, double Latitude, double Longitude,
+                      double WindSpeed, double WindAngle, tN2kWindReference WindReference, double WindGusts, 
+                      char *StationID, char* StationName, double AtmosphericPressure=N2kDoubleNA, 
+                      double OutsideAmbientAirTemperature=N2kDoubleNA);
+
+inline void SetN2kMeteorlogicalStationData(tN2kMsg &N2kMsg, uint16_t SystemDate, double SystemTime, double Latitude, double Longitude,
+                      double WindSpeed, double WindAngle, tN2kWindReference WindReference, double WindGusts, 
+                      char *StationID, char* StationName, double AtmosphericPressure=N2kDoubleNA, 
+                      double OutsideAmbientAirTemperature=N2kDoubleNA) {
+  SetN2kPGN130323(N2kMsg, SystemDate, SystemTime, Latitude, Longitude,
+                      WindSpeed, WindAngle, WindReference, WindGusts, 
+                      StationID, StationName, AtmosphericPressure, 
+                      OutsideAmbientAirTemperature);
+}
+
+bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, uint16_t &SystemDate, double &SystemTime, double &Latitude, double &Longitude,
+                      double &WindSpeed, double &WindAngle, tN2kWindReference &WindReference, double &WindGusts, 
+                      char *StationID, size_t StationIDMaxSize, char* StationName, size_t StationNameMaxSize, 
+                      double &AtmosphericPressure, double &OutsideAmbientAirTemperature);
+inline bool ParseN2kMeteorlogicalStationData(const tN2kMsg &N2kMsg, uint16_t &SystemDate, double &SystemTime, double &Latitude, 
+                      double &Longitude, double &WindSpeed, double &WindAngle, tN2kWindReference &WindReference, double &WindGusts, 
+                      char *StationID, size_t StationIDMaxSize, char* StationName, size_t StationNameMaxSize, 
+                      double &AtmosphericPressure, double &OutsideAmbientAirTemperature) {
+  return ParseN2kPGN130323(N2kMsg, SystemDate, SystemTime, Latitude, Longitude,
+                      WindSpeed, WindAngle, WindReference, WindGusts, 
+                      StationID, StationIDMaxSize, StationName, StationNameMaxSize, AtmosphericPressure, 
+                      OutsideAmbientAirTemperature);
+}
 
 //*****************************************************************************
 // Small Craft Status (Trim Tab Position)

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -1813,48 +1813,47 @@ inline bool ParseN2kTemperatureExt(const tN2kMsg &N2kMsg, unsigned char &SID, un
 //*****************************************************************************
 // Meteorlogical Station Data
 // Input:
-//  - SID                   Sequence ID.
 //  - SystemDate            Days since 1970-01-01
 //  - SystemTime            seconds since midnight
 //  - Latitude              The latitude of the current waypoint
 //  - Longitude             The longitude of the current waypoint
 //  - WindSpeed             Measured wind speed in m/s
-//  - WindAngle             Measured wind angle in radians. If you have value in degrees, use function DegToRad(myval) in call.
+//  - WindDirection         Measured wind direction in radians. If you have value in degrees, use function DegToRad(myval) in call.
 //  - WindReference         Wind reference, see definition of tN2kWindReference
 //  - WindGusts             Measured wind gusts speed in m/s
 //  - AtmosphericPressure   Atmospheric pressure in Pascals. Use function mBarToPascal, if you like to use mBar
 //  - OutsideAmbientAirTemperature      Outside ambient temperature in K. Use function CToKelvin, if you want to use °C.
-//  - StationID             Identifier of the transmitting weather station. (255 bytes max)
-//  - StationName           Friendly name of the transmitting weather station. (255 bytes max)
+//  - StationID             Identifier of the transmitting weather station. (15 bytes max)
+//  - StationName           Friendly name of the transmitting weather station. (50 bytes max)
 //  
 //
 // Output:
-//  - N2kMsg                NMEA2000 message ready to be send.
-void SetN2kPGN130323(tN2kMsg &N2kMsg, uint16_t SystemDate, double SystemTime, double Latitude, double Longitude,
-                      double WindSpeed, double WindAngle, tN2kWindReference WindReference, double WindGusts, 
-                      char *StationID, char* StationName, double AtmosphericPressure=N2kDoubleNA, 
+//  - N2kMsg                NMEA2000 message ready to be sent.
+void SetN2kPGN130323(tN2kMsg &N2kMsg, tN2kAISMode Mode, uint16_t SystemDate, double SystemTime, double Latitude, double Longitude,
+                      double WindSpeed, double WindDirection, tN2kWindReference WindReference, double WindGusts, 
+                      const char *StationID, const char* StationName, double AtmosphericPressure=N2kDoubleNA, 
                       double OutsideAmbientAirTemperature=N2kDoubleNA);
 
-inline void SetN2kMeteorlogicalStationData(tN2kMsg &N2kMsg, uint16_t SystemDate, double SystemTime, double Latitude, double Longitude,
-                      double WindSpeed, double WindAngle, tN2kWindReference WindReference, double WindGusts, 
-                      char *StationID, char* StationName, double AtmosphericPressure=N2kDoubleNA, 
+inline void SetN2kMeteorlogicalStationData(tN2kMsg &N2kMsg, tN2kAISMode Mode,  uint16_t SystemDate, double SystemTime, 
+                      double Latitude, double Longitude, double WindSpeed, double WindDirection, tN2kWindReference WindReference,
+                      double WindGusts, const char *StationID, const char* StationName, double AtmosphericPressure=N2kDoubleNA, 
                       double OutsideAmbientAirTemperature=N2kDoubleNA) {
-  SetN2kPGN130323(N2kMsg, SystemDate, SystemTime, Latitude, Longitude,
-                      WindSpeed, WindAngle, WindReference, WindGusts, 
+  SetN2kPGN130323(N2kMsg, Mode, SystemDate, SystemTime, Latitude, Longitude,
+                      WindSpeed, WindDirection, WindReference, WindGusts, 
                       StationID, StationName, AtmosphericPressure, 
                       OutsideAmbientAirTemperature);
 }
 
-bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, uint16_t &SystemDate, double &SystemTime, double &Latitude, double &Longitude,
-                      double &WindSpeed, double &WindAngle, tN2kWindReference &WindReference, double &WindGusts, 
-                      char *StationID, size_t StationIDMaxSize, char* StationName, size_t StationNameMaxSize, 
+bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, tN2kAISMode &Mode, uint16_t &SystemDate, double &SystemTime, double &Latitude, 
+                      double &Longitude, double &WindSpeed, double &WindDirection, tN2kWindReference &WindReference,
+                      double &WindGusts, char *StationID, size_t StationIDMaxSize, char* StationName, size_t StationNameMaxSize, 
                       double &AtmosphericPressure, double &OutsideAmbientAirTemperature);
-inline bool ParseN2kMeteorlogicalStationData(const tN2kMsg &N2kMsg, uint16_t &SystemDate, double &SystemTime, double &Latitude, 
-                      double &Longitude, double &WindSpeed, double &WindAngle, tN2kWindReference &WindReference, double &WindGusts, 
-                      char *StationID, size_t StationIDMaxSize, char* StationName, size_t StationNameMaxSize, 
-                      double &AtmosphericPressure, double &OutsideAmbientAirTemperature) {
-  return ParseN2kPGN130323(N2kMsg, SystemDate, SystemTime, Latitude, Longitude,
-                      WindSpeed, WindAngle, WindReference, WindGusts, 
+inline bool ParseN2kMeteorlogicalStationData(const tN2kMsg &N2kMsg, tN2kAISMode &Mode, uint16_t &SystemDate, double &SystemTime,
+                      double &Latitude, double &Longitude, double &WindSpeed, double &WindDirection, 
+                      tN2kWindReference &WindReference, double &WindGusts, char *StationID, size_t StationIDMaxSize, 
+                      char* StationName, size_t StationNameMaxSize, double &AtmosphericPressure, double &OutsideAmbientAirTemperature) {
+  return ParseN2kPGN130323(N2kMsg, Mode, SystemDate, SystemTime, Latitude, Longitude,
+                      WindSpeed, WindDirection, WindReference, WindGusts, 
                       StationID, StationIDMaxSize, StationName, StationNameMaxSize, AtmosphericPressure, 
                       OutsideAmbientAirTemperature);
 }

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -1829,33 +1829,32 @@ inline bool ParseN2kTemperatureExt(const tN2kMsg &N2kMsg, unsigned char &SID, un
 //
 // Output:
 //  - N2kMsg                NMEA2000 message ready to be sent.
-void SetN2kPGN130323(tN2kMsg &N2kMsg, tN2kAISMode Mode, uint16_t SystemDate, double SystemTime, double Latitude, double Longitude,
-                      double WindSpeed, double WindDirection, tN2kWindReference WindReference, double WindGusts, 
-                      const char *StationID, const char* StationName, double AtmosphericPressure=N2kDoubleNA, 
-                      double OutsideAmbientAirTemperature=N2kDoubleNA);
+//*****************************************************************************
+typedef struct tN2kPGN130323Data {
+  tN2kAISMode Mode;
+  uint16_t SystemDate;
+  double SystemTime;
+  double Latitude;
+  double Longitude;
+  double WindSpeed;
+  double WindDirection;
+  tN2kWindReference WindReference;
+  double WindGusts;
+  double AtmosphericPressure;
+  double OutsideAmbientAirTemperature;
+  char StationID[15];
+  char StationName[50];
+} tN2kMeteorlogicalStationData;
 
-inline void SetN2kMeteorlogicalStationData(tN2kMsg &N2kMsg, tN2kAISMode Mode,  uint16_t SystemDate, double SystemTime, 
-                      double Latitude, double Longitude, double WindSpeed, double WindDirection, tN2kWindReference WindReference,
-                      double WindGusts, const char *StationID, const char* StationName, double AtmosphericPressure=N2kDoubleNA, 
-                      double OutsideAmbientAirTemperature=N2kDoubleNA) {
-  SetN2kPGN130323(N2kMsg, Mode, SystemDate, SystemTime, Latitude, Longitude,
-                      WindSpeed, WindDirection, WindReference, WindGusts, 
-                      StationID, StationName, AtmosphericPressure, 
-                      OutsideAmbientAirTemperature);
-}
+void SetN2kPGN130323(tN2kMsg &N2kMsg, const tN2kMeteorlogicalStationData N2kData);
+inline void SetN2kMeteorlogicalStationData(tN2kMsg &N2kMsg, const tN2kMeteorlogicalStationData N2kData) { SetN2kPGN130323(N2kMsg, N2kData); }
 
-bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, tN2kAISMode &Mode, uint16_t &SystemDate, double &SystemTime, double &Latitude, 
-                      double &Longitude, double &WindSpeed, double &WindDirection, tN2kWindReference &WindReference,
-                      double &WindGusts, char *StationID, size_t StationIDMaxSize, char* StationName, size_t StationNameMaxSize, 
-                      double &AtmosphericPressure, double &OutsideAmbientAirTemperature);
-inline bool ParseN2kMeteorlogicalStationData(const tN2kMsg &N2kMsg, tN2kAISMode &Mode, uint16_t &SystemDate, double &SystemTime,
-                      double &Latitude, double &Longitude, double &WindSpeed, double &WindDirection, 
-                      tN2kWindReference &WindReference, double &WindGusts, char *StationID, size_t StationIDMaxSize, 
-                      char* StationName, size_t StationNameMaxSize, double &AtmosphericPressure, double &OutsideAmbientAirTemperature) {
-  return ParseN2kPGN130323(N2kMsg, Mode, SystemDate, SystemTime, Latitude, Longitude,
-                      WindSpeed, WindDirection, WindReference, WindGusts, 
-                      StationID, StationIDMaxSize, StationName, StationNameMaxSize, AtmosphericPressure, 
-                      OutsideAmbientAirTemperature);
+bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, tN2kMeteorlogicalStationData &N2kData,
+                        size_t StationIDMaxSize=15, size_t StationNameMaxSize=50);
+
+inline bool ParseN2kMeteorlogicalStationData(const tN2kMsg &N2kMsg, tN2kMeteorlogicalStationData &N2kData, 
+                                              size_t StationIDMaxSize=15, size_t StationNameMaxSize=50) {
+  return ParseN2kPGN130323(N2kMsg, N2kData, StationIDMaxSize, StationNameMaxSize);
 }
 
 //*****************************************************************************

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -38,6 +38,7 @@ NMEA2000.h
 
 #include "N2kMsg.h"
 #include "N2kTypes.h"
+#include <cstring>
 #include <stdint.h>
 
 inline double RadToDeg(double v) { return N2kIsNA(v)?v:v*180.0/3.1415926535897932384626433832795L; }
@@ -1830,7 +1831,7 @@ inline bool ParseN2kTemperatureExt(const tN2kMsg &N2kMsg, unsigned char &SID, un
 // Output:
 //  - N2kMsg                NMEA2000 message ready to be sent.
 //*****************************************************************************
-typedef struct tN2kPGN130323Data {
+struct tN2kMeteorlogicalStationData {
   tN2kAISMode Mode;
   uint16_t SystemDate;
   double SystemTime;
@@ -1844,10 +1845,36 @@ typedef struct tN2kPGN130323Data {
   double OutsideAmbientAirTemperature;
   char StationID[15];
   char StationName[50];
-} tN2kMeteorlogicalStationData;
 
-void SetN2kPGN130323(tN2kMsg &N2kMsg, const tN2kMeteorlogicalStationData N2kData);
-inline void SetN2kMeteorlogicalStationData(tN2kMsg &N2kMsg, const tN2kMeteorlogicalStationData N2kData) { SetN2kPGN130323(N2kMsg, N2kData); }
+  tN2kMeteorlogicalStationData():
+    Mode(N2kaismode_Autonomous),
+    SystemDate(N2kUInt16NA),
+    SystemTime(N2kDoubleNA),
+    Latitude(N2kDoubleNA),
+    Longitude(N2kDoubleNA),
+    WindSpeed(N2kDoubleNA),
+    WindDirection(N2kDoubleNA),
+    WindReference(N2kWind_Unavailable),
+    WindGusts(N2kDoubleNA),
+    AtmosphericPressure(N2kDoubleNA),
+    OutsideAmbientAirTemperature(N2kDoubleNA) {
+      StationID[0] = 0;
+      StationName[0] = 0;
+    }
+
+  void SetStationID(const char *id) {
+    strncpy(StationID, id, sizeof(StationID));
+    StationID[sizeof(StationID) - 1] = 0;
+  }
+
+  void SetStationName(const char *name) {
+    strncpy(StationName, name, sizeof(StationName));
+    StationName[sizeof(StationName) - 1] = 0;
+  }
+};
+
+void SetN2kPGN130323(tN2kMsg &N2kMsg, const tN2kMeteorlogicalStationData &N2kData);
+inline void SetN2kMeteorlogicalStationData(tN2kMsg &N2kMsg, const tN2kMeteorlogicalStationData &N2kData) { SetN2kPGN130323(N2kMsg, N2kData); }
 
 bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, tN2kMeteorlogicalStationData &N2kData,
                         size_t StationIDMaxSize=15, size_t StationNameMaxSize=50);

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -1843,8 +1843,8 @@ struct tN2kMeteorlogicalStationData {
   double WindGusts;
   double AtmosphericPressure;
   double OutsideAmbientAirTemperature;
-  char StationID[15];
-  char StationName[50];
+  char StationID[15 + 1];
+  char StationName[50 + 1];
 
   tN2kMeteorlogicalStationData():
     Mode(N2kaismode_Autonomous),
@@ -1876,12 +1876,9 @@ struct tN2kMeteorlogicalStationData {
 void SetN2kPGN130323(tN2kMsg &N2kMsg, const tN2kMeteorlogicalStationData &N2kData);
 inline void SetN2kMeteorlogicalStationData(tN2kMsg &N2kMsg, const tN2kMeteorlogicalStationData &N2kData) { SetN2kPGN130323(N2kMsg, N2kData); }
 
-bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, tN2kMeteorlogicalStationData &N2kData,
-                        size_t StationIDMaxSize=15, size_t StationNameMaxSize=50);
-
-inline bool ParseN2kMeteorlogicalStationData(const tN2kMsg &N2kMsg, tN2kMeteorlogicalStationData &N2kData, 
-                                              size_t StationIDMaxSize=15, size_t StationNameMaxSize=50) {
-  return ParseN2kPGN130323(N2kMsg, N2kData, StationIDMaxSize, StationNameMaxSize);
+bool ParseN2kPGN130323(const tN2kMsg &N2kMsg, tN2kMeteorlogicalStationData &N2kData);
+inline bool ParseN2kMeteorlogicalStationData(const tN2kMsg &N2kMsg, tN2kMeteorlogicalStationData &N2kData) {
+  return ParseN2kPGN130323(N2kMsg, N2kData);
 }
 
 //*****************************************************************************

--- a/src/N2kTypes.h
+++ b/src/N2kTypes.h
@@ -361,13 +361,6 @@ enum tN2kMOBEmitterBatteryStatus {
                            Good=0,
                            Low=1,
                           };
-enum tN2kDataMode {
-                           Autonomous = 0,
-                           DifferentialEnhanced = 1,
-                           Estimated = 2,
-                           Simulator = 3,
-                           Manual = 4
-                           };
 
 //*****************************************************************************
 // Aliases for N2K standard types.
@@ -390,6 +383,16 @@ using tN2kGenericStatusPair = tN2kDD002;
                   // N2kDD002_Set=N2kDD002_Yes
                   // N2kDD002_1=N2kDD002_Yes
                   // N2kDD002_Unknown=N2kDD002_Unavailable                         
+                  
+using tN2kDataMode = tN2kDD025;
+            // Enum type members:
+                  // N2kDD025_Autonomous=0,
+                  // N2kDD025_Differential=1,
+                  // N2kDD025_Estimated=2,
+                  // N2kDD025_Simulator=3,
+                  // N2kDD025_Manual=4,
+                  // N2kDD025_Error=0xe,
+                  // N2kDD025_Unavailable=0xf
 
 using tN2kRangeResidualMode = tN2kDD072;
                   // N2kDD072_RangeResidualsWereUsedToCalculateData=0,
@@ -492,6 +495,7 @@ using tN2kSpeedType = tN2kDD488;
                             // N2kDD488_DualSpeed=1
                             // N2kDD488_ProportionalSpeed=2
                             // N2kDD488_DataNotAvailable=3
+
 
 #endif
 

--- a/src/NMEA2000StdTypes.h
+++ b/src/NMEA2000StdTypes.h
@@ -58,6 +58,16 @@ enum tN2kDD002 {
                   N2kDD002_1=N2kDD002_Yes,
                   N2kDD002_Unknown=N2kDD002_Unavailable
                 };
+
+enum tN2kDD025 {
+                  N2kDD025_Autonomous=0,
+                  N2kDD025_Differential=1,
+                  N2kDD025_Estimated=2,
+                  N2kDD025_Simulator=3,
+                  N2kDD025_Manual=4,
+                  N2kDD025_Error=0xe,
+                  N2kDD025_Unavailable=0xf
+                };
                           
 enum tN2kDD072 {
                   N2kDD072_RangeResidualsWereUsedToCalculateData=0,
@@ -264,6 +274,8 @@ enum tN2kDD488 {
                             N2kDD488_ProportionalSpeed=2,
                             N2kDD488_DataNotAvailable=3
                           };
+
+
 
 #endif
 

--- a/test/N2kMessagesTest.cpp
+++ b/test/N2kMessagesTest.cpp
@@ -163,73 +163,45 @@ TEST_CASE("PGN129039 AIS Class B Position")
 TEST_CASE("PGN130323 Meteorlogical Station Data")
 {
   tN2kMsg N2kMsg;
-  tN2kAISMode Mode[2] = {N2kaismode_Assigned, N2kaismode_Autonomous};
-  uint16_t SystemDate[2] = {10, 0};
-  double SystemTime[2] = {10.9, 0};
-  double Latitude[2] = {-33.0,0};
-  double Longitude[2] = {151.0,0};
-  double WindSpeed[2] = {12.3, 0};
-  double WindDirection[2] = {2.1, 0};
-  tN2kWindReference WindReference[2] = {N2kWind_True_North, N2kWind_Magnetic};
-  double WindGusts[2] = {12.3, 0};
-  const char *StationID_TX = "StationID";
+
+  tN2kMeteorlogicalStationData data_tx = {
+    N2kaismode_Assigned,
+    10,
+    10.9,
+    -33.0,
+    151.0,
+    12.3,
+    2.1,
+    N2kWind_True_North,
+    12.3,
+    100,
+    12.3,
+    "StationID",
+    "StationName",
+  };
+
+  SetN2kPGN130323(N2kMsg, data_tx);
+
+  tN2kMeteorlogicalStationData data_rx;
   size_t StationIDMaxSize = 15;
-  const char *StationName_TX = "StationName";
   size_t StationNameMaxSize = 50;
-  double AtmosphericPressure[2] = {100, 0};
-  double OutsideAmbientAirTemperature[2] = {12.3, 0};
-
-  SetN2kPGN130323(
-    N2kMsg,
-    Mode[0], 
-    SystemDate[0], 
-    SystemTime[0],
-    Latitude[0],
-    Longitude[0],
-    WindSpeed[0],
-    WindDirection[0],
-    WindReference[0],
-    WindGusts[0],
-    (char*)StationID_TX,
-    (char*)StationName_TX,
-    AtmosphericPressure[0],
-    OutsideAmbientAirTemperature[0]);
-
-  char StationID_RX[15];
-  char StationName_RX[50];
-  ParseN2kPGN130323(
-    N2kMsg,
-    Mode[1], 
-    SystemDate[1],
-    SystemTime[1],
-    Latitude[1],
-    Longitude[1],
-    WindSpeed[1],
-    WindDirection[1],
-    WindReference[1],
-    WindGusts[1],
-    StationID_RX,
-    StationIDMaxSize,
-    StationName_RX,
-    StationNameMaxSize,
-    AtmosphericPressure[1],
-    OutsideAmbientAirTemperature[1]);
+  ParseN2kPGN130323(N2kMsg, data_rx, StationIDMaxSize, StationIDMaxSize);
 
   SECTION("parsed values match set values")
   {
-    REQUIRE(Mode[0] ==                            Mode[1]);
-    REQUIRE(SystemDate[0] ==                      SystemDate[1]);
-    REQUIRE(SystemTime[0] ==                      SystemTime[1]);
-    REQUIRE(Latitude[0] ==                        Latitude[1]);
-    REQUIRE(Longitude[0] ==                       Longitude[1]);
-    REQUIRE(WindSpeed[0] ==                       WindSpeed[1]);
-    REQUIRE(WindDirection[0] ==                   WindDirection[1]);
-    REQUIRE(WindReference[0] ==                   WindReference[1]);
-    REQUIRE(WindGusts[0] ==                       WindGusts[1]);
-    REQUIRE(AtmosphericPressure[0] ==             AtmosphericPressure[1]);
-    REQUIRE(OutsideAmbientAirTemperature[0] ==    OutsideAmbientAirTemperature[1]);
-    REQUIRE(strcmp(StationID_TX,                  StationID_RX) == 0);
-    REQUIRE(strcmp(StationName_TX,                StationName_RX) == 0);
+    REQUIRE(data_tx.Mode ==                            data_rx.Mode);
+    REQUIRE(data_tx.SystemDate ==                      data_rx.SystemDate);
+    REQUIRE(data_tx.SystemTime ==                      data_rx.SystemTime);
+    REQUIRE(data_tx.Latitude ==                        data_rx.Latitude);
+    REQUIRE(data_tx.Longitude ==                       data_rx.Longitude);
+    REQUIRE(data_tx.WindSpeed ==                       data_rx.WindSpeed);
+    REQUIRE(data_tx.WindDirection ==                   data_rx.WindDirection);
+    REQUIRE(data_tx.WindReference ==                   data_rx.WindReference);
+    REQUIRE(data_tx.WindGusts ==                       data_rx.WindGusts);
+    REQUIRE(data_tx.AtmosphericPressure ==             data_rx.AtmosphericPressure);
+    REQUIRE(data_tx.OutsideAmbientAirTemperature ==    data_rx.OutsideAmbientAirTemperature);
+    REQUIRE(strcmp(data_tx.StationID,                  data_rx.StationID) == 0);
+    REQUIRE(strcmp(data_tx.StationName,                data_rx.StationName) == 0);
    }
 
 }

--- a/test/N2kMessagesTest.cpp
+++ b/test/N2kMessagesTest.cpp
@@ -164,21 +164,21 @@ TEST_CASE("PGN130323 Meteorlogical Station Data")
 {
   tN2kMsg N2kMsg;
 
-  tN2kMeteorlogicalStationData data_tx = {
-    N2kaismode_Assigned,
-    10,
-    10.9,
-    -33.0,
-    151.0,
-    12.3,
-    2.1,
-    N2kWind_True_North,
-    12.3,
-    100,
-    12.3,
-    "StationID",
-    "StationName",
-  };
+  tN2kMeteorlogicalStationData data_tx;
+
+  data_tx.Mode = N2kaismode_Assigned;
+  data_tx.SystemDate = 10;
+  data_tx.SystemTime = 10.8;
+  data_tx.Latitude = -33.1;
+  data_tx.Longitude = 151.6;
+  data_tx.WindSpeed = 12.3;
+  data_tx.WindDirection = 2.1;
+  data_tx.WindReference = N2kWind_True_North;
+  data_tx.WindGusts = 12.3;
+  data_tx.AtmosphericPressure = 100;
+  data_tx.OutsideAmbientAirTemperature= 19.1;
+  data_tx.SetStationID("AX12");
+  data_tx.SetStationName("StationName");
 
   SetN2kPGN130323(N2kMsg, data_tx);
 

--- a/test/N2kMessagesTest.cpp
+++ b/test/N2kMessagesTest.cpp
@@ -160,6 +160,76 @@ TEST_CASE("PGN129039 AIS Class B Position")
       }
 }
 
+TEST_CASE("PGN130323 Meteorlogical Station Data")
+{
+  tN2kMsg N2kMsg;
+  uint16_t SystemDate[2] = {10, 0};
+  double SystemTime[2] = {10.9, 0};
+  double Latitude[2] = {-33.0,0};
+  double Longitude[2] = {151.0,0};
+  double WindSpeed[2] = {12.3, 0};
+  double WindAngle[2] = {12.3, 0};
+  tN2kWindReference WindReference[2] = {N2kWind_True_North, N2kWind_Magnetic};
+  double WindGusts[2] = {12.3, 0};
+  const char *StationID_TX = "StationID";
+  size_t StationIDMaxSize = 15;
+  const char *StationName_TX = "StationName";
+  size_t StationNameMaxSize = 50;
+  double AtmosphericPressure[2] = {100, 0};
+  double OutsideAmbientAirTemperature[2] = {12.3, 0};
+
+  SetN2kPGN130323(
+    N2kMsg,
+    SystemDate[0], 
+    SystemTime[0],
+    Latitude[0],
+    Longitude[0],
+    WindSpeed[0],
+    WindAngle[0],
+    WindReference[0],
+    WindGusts[0],
+    (char*)StationID_TX,
+    (char*)StationName_TX,
+    AtmosphericPressure[0],
+    OutsideAmbientAirTemperature[0]);
+
+  char StationID_RX[15];
+  char StationName_RX[50];
+  ParseN2kPGN130323(
+    N2kMsg,
+    SystemDate[1],
+    SystemTime[1],
+    Latitude[1],
+    Longitude[1],
+    WindSpeed[1],
+    WindAngle[1],
+    WindReference[1],
+    WindGusts[1],
+    StationID_RX,
+    StationIDMaxSize,
+    StationName_RX,
+    StationNameMaxSize,
+    AtmosphericPressure[1],
+    OutsideAmbientAirTemperature[1]);
+
+  SECTION("parsed values match set values")
+  {
+    REQUIRE(SystemDate[0] ==                      SystemDate[1]);
+    REQUIRE(SystemTime[0] ==                      SystemTime[1]);
+    REQUIRE(Latitude[0] ==                        Latitude[1]);
+    REQUIRE(Longitude[0] ==                       Longitude[1]);
+    REQUIRE(WindSpeed[0] ==                       WindSpeed[1]);
+    REQUIRE(WindAngle[0] ==                       WindAngle[1]);
+    REQUIRE(WindReference[0] ==                   WindReference[1]);
+    REQUIRE(WindGusts[0] ==                       WindGusts[1]);
+    REQUIRE(AtmosphericPressure[0] ==             AtmosphericPressure[1]);
+    REQUIRE(OutsideAmbientAirTemperature[0] ==    OutsideAmbientAirTemperature[1]);
+    REQUIRE(strcmp(StationID_TX,                  StationID_RX) == 0);
+    REQUIRE(strcmp(StationName_TX,                StationName_RX) == 0);
+   }
+
+}
+
 TEST_CASE("PGN130577 Direction Data")
 {
   tN2kMsg N2kMsg;

--- a/test/N2kMessagesTest.cpp
+++ b/test/N2kMessagesTest.cpp
@@ -163,12 +163,13 @@ TEST_CASE("PGN129039 AIS Class B Position")
 TEST_CASE("PGN130323 Meteorlogical Station Data")
 {
   tN2kMsg N2kMsg;
+  tN2kAISMode Mode[2] = {N2kaismode_Assigned, N2kaismode_Autonomous};
   uint16_t SystemDate[2] = {10, 0};
   double SystemTime[2] = {10.9, 0};
   double Latitude[2] = {-33.0,0};
   double Longitude[2] = {151.0,0};
   double WindSpeed[2] = {12.3, 0};
-  double WindAngle[2] = {12.3, 0};
+  double WindDirection[2] = {2.1, 0};
   tN2kWindReference WindReference[2] = {N2kWind_True_North, N2kWind_Magnetic};
   double WindGusts[2] = {12.3, 0};
   const char *StationID_TX = "StationID";
@@ -180,12 +181,13 @@ TEST_CASE("PGN130323 Meteorlogical Station Data")
 
   SetN2kPGN130323(
     N2kMsg,
+    Mode[0], 
     SystemDate[0], 
     SystemTime[0],
     Latitude[0],
     Longitude[0],
     WindSpeed[0],
-    WindAngle[0],
+    WindDirection[0],
     WindReference[0],
     WindGusts[0],
     (char*)StationID_TX,
@@ -197,12 +199,13 @@ TEST_CASE("PGN130323 Meteorlogical Station Data")
   char StationName_RX[50];
   ParseN2kPGN130323(
     N2kMsg,
+    Mode[1], 
     SystemDate[1],
     SystemTime[1],
     Latitude[1],
     Longitude[1],
     WindSpeed[1],
-    WindAngle[1],
+    WindDirection[1],
     WindReference[1],
     WindGusts[1],
     StationID_RX,
@@ -214,12 +217,13 @@ TEST_CASE("PGN130323 Meteorlogical Station Data")
 
   SECTION("parsed values match set values")
   {
+    REQUIRE(Mode[0] ==                            Mode[1]);
     REQUIRE(SystemDate[0] ==                      SystemDate[1]);
     REQUIRE(SystemTime[0] ==                      SystemTime[1]);
     REQUIRE(Latitude[0] ==                        Latitude[1]);
     REQUIRE(Longitude[0] ==                       Longitude[1]);
     REQUIRE(WindSpeed[0] ==                       WindSpeed[1]);
-    REQUIRE(WindAngle[0] ==                       WindAngle[1]);
+    REQUIRE(WindDirection[0] ==                   WindDirection[1]);
     REQUIRE(WindReference[0] ==                   WindReference[1]);
     REQUIRE(WindGusts[0] ==                       WindGusts[1]);
     REQUIRE(AtmosphericPressure[0] ==             AtmosphericPressure[1]);

--- a/test/N2kMessagesTest.cpp
+++ b/test/N2kMessagesTest.cpp
@@ -183,9 +183,7 @@ TEST_CASE("PGN130323 Meteorlogical Station Data")
   SetN2kPGN130323(N2kMsg, data_tx);
 
   tN2kMeteorlogicalStationData data_rx;
-  size_t StationIDMaxSize = 15;
-  size_t StationNameMaxSize = 50;
-  ParseN2kPGN130323(N2kMsg, data_rx, StationIDMaxSize, StationIDMaxSize);
+  ParseN2kPGN130323(N2kMsg, data_rx);
 
   SECTION("parsed values match set values")
   {
@@ -209,7 +207,7 @@ TEST_CASE("PGN130323 Meteorlogical Station Data")
 TEST_CASE("PGN130577 Direction Data")
 {
   tN2kMsg N2kMsg;
-  tN2kDataMode DataMode[2] = {Simulator,Simulator};
+  tN2kDataMode DataMode[2] = {N2kDD025_Simulator,N2kDD025_Simulator};
   tN2kHeadingReference CogReference[2] = {N2khr_magnetic,N2khr_magnetic};
   unsigned char SID[2] = {3,0};
   double COG[2] = {0.1,0};


### PR DESCRIPTION
I have added support for a missing PGN that I needed parsed on my system.  

- Added PGN 130323 as described in [this document.](http://seasmart.net/pdf/SeaSmart_HTTP_Protocol_RevG_043012.pdf)
- Tested based on data from a Airmar 200WX weather station.
- Added unittest