### PR TITLE
SOCKET_CAN_PORT is extern char* for better external library integration

### DIFF
--- a/src/NMEA2000_CAN.h
+++ b/src/NMEA2000_CAN.h
@@ -155,9 +155,7 @@ tNMEA2000 &NMEA2000=*(new tNMEA2000_avr());
 
 #elif USE_N2K_CAN == USE_N2K_SOCKET_CAN
 // Use socketCAN devices
-#ifndef SOCKET_CAN_PORT
-  #define SOCKET_CAN_PORT NULL
-  #endif
+extern char* SOCKET_CAN_PORT;
 #include <NMEA2000_SocketCAN.h>       // https://github.com/thomasonw/NMEA2000_socketCAN
 tNMEA2000 &NMEA2000=*(new tNMEA2000_SocketCAN(SOCKET_CAN_PORT));
 tSocketStream serStream;


### PR DESCRIPTION
Hey, I was building your library into another personal one and realized that this #define doesn't get set properly when compiling into another project. 

It also can't be set at runtime in any applications which isn't too useful.

Is this a breaking code change or would this work to replace define? 

I tested with my builds and seemed to work without complaints.

Cheers 