### PR TITLE
Three-byte doubles should be three bytes, not four

### DIFF
--- a/src/N2kMsg.cpp
+++ b/src/N2kMsg.cpp
@@ -600,7 +600,7 @@ void SetBuf4ByteUDouble(double v, double precision, int &index, unsigned char *b
 void SetBuf3ByteDouble(double v, double precision, int &index, unsigned char *buf) {
   double vd=round(v/precision);
   int32_t vi = (vd>=N2kInt24Min && vd<N2kInt24OR)?(int32_t)vd:N2kInt24OR;
-  SetBuf<int32_t>(vi, 4, index, buf);
+  SetBuf<int32_t>(vi, 3, index, buf);
 }
 
 //*****************************************************************************


### PR DESCRIPTION
This is not a one-liner but a one-character-er:

It seems like commit a75f6369a25e broke `N2kMsg.cpp:SetBuf3ByteDouble()`: the signal is written as 4 bytes instead of 3. This messes up e.g. PGN 130316. Fix was, eh, quite simple... :-)