### PR TITLE
PGN 127502

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.configureOnOpen": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "cmake.configureOnOpen": false
-}

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -633,6 +633,29 @@ bool ParseN2kPGN127501(const tN2kMsg &N2kMsg, unsigned char &DeviceBankInstance,
 }
 
 //*****************************************************************************
+// PGN 127502 - Switch Bank Control
+
+bool ParseN2kPGN127502(const tN2kMsg &N2kMsg, unsigned char &TargetBankInstance, tN2kBinaryStatus &BankStatus) {
+  if (N2kMsg.PGN!=127502L) return false;
+
+  int Index=0;
+  BankStatus=N2kMsg.GetUInt64(Index);
+  TargetBankInstance = BankStatus & 0xff;
+  BankStatus>>=8;
+
+  return true;
+}
+
+//*****************************************************************************
+
+void SetN2kPGN127502(tN2kMsg &N2kMsg, unsigned char TargetBankInstance, tN2kBinaryStatus BankStatus) {
+  N2kMsg.SetPGN(127502L);
+  N2kMsg.Priority=3;
+	BankStatus = (BankStatus << 8) | TargetBankInstance;
+	N2kMsg.AddUInt64(BankStatus);
+}
+
+//*****************************************************************************
 // Fluid level
 void SetN2kPGN127505(tN2kMsg &N2kMsg, unsigned char Instance, tN2kFluidType FluidType, double Level, double Capacity) {
     N2kMsg.SetPGN(127505L);

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -1807,6 +1807,64 @@ inline bool ParseN2kBinaryStatus(const tN2kMsg &N2kMsg, unsigned char &DeviceBan
 }
 
 /************************************************************************//**
+ * \brief Parse the content of a PGN 127502 (Switch Bank Control) message
+ * \ingroup group_msgParsers
+ * 
+ * \param N2kMsg              Reference to the N2kMsg object to be parsed. If
+ *                            this contains a valid PGN 127502 message then
+ *                            the following return values will be set. 
+ * \param TargetBankInstance  Instance number of the switchbank that was
+ *                            targetted by this switchbank control message.
+ * \param BankStatus          The binary status component of the switchbank
+ *                            control containing the commanded state of channels
+ *                            on the target switchbank.
+ *                            \ref N2kGetStatusOnBinaryStatus
+ * 
+ * \return true               Parsing of PGN Message successful
+ * \return false              Parsing of PGN Message aborted
+ */
+bool ParseN2kPGN127502(const tN2kMsg &N2kMsg, unsigned char &TargetBankInstance, tN2kBinaryStatus &BankStatus);
+
+/************************************************************************//**
+ * \brief Parse PGN 127502 "Switch Bank Control" message.
+ * \ingroup group_msgSetUp
+ * 
+ * Alias of \ref ParseN2kPGN127502. This alias was introduced to improve the
+ * readability of the source code.
+ */
+inline bool ParseN2kSwitchbankControl(const tN2kMsg &N2kMsg, unsigned char &TargetBankInstance, tN2kBinaryStatus &BankStatus) {
+  return ParseN2kPGN127502(N2kMsg, TargetBankInstance, BankStatus);
+}
+
+/************************************************************************//**
+ * \brief Set up PGN 127502 "Switch Bank Control" message.
+ * \ingroup group_msgSetUp
+ * 
+ * Command channel states on a remote switch bank. Up to 28 remote binary
+ * states can be controlled.
+ *
+ * \param N2kMsg              Reference to an N2kMsg Object which will be
+ *                            configured for sending on the NMEA bus. 
+ * \param DeviceBankInstance  Instance number of the target switchbank (i.e.
+ *                            the device to be controlled).
+ * \param BankStatus          Full bank status containing the channel states
+ *                            to to be commanded on the remote switchbank.
+ *                            \ref N2kGetStatusOnBinaryStatus
+ */
+void SetN2kPGN127502(tN2kMsg &N2kMsg, unsigned char TargetBankInstance, tN2kBinaryStatus BankStatus);
+
+/************************************************************************//**
+ * \brief Set up PGN 127502 "Switch Bank Control" message.
+ * \ingroup group_msgSetUp
+ * 
+ * Alias of \ref SetN2kPGN127502. This alias was introduced to improve the
+ * readability of the source code.
+ */
+inline void SetN2kSwitchbankControl(tN2kMsg &N2kMsg, unsigned char TargetBankInstance, tN2kBinaryStatus BankStatus) {
+	SetN2kPGN127502(N2kMsg, TargetBankInstance, BankStatus);
+}
+
+/************************************************************************//**
  * \brief Setting up PGN 127505 Message "Fluid level"
  * \ingroup group_msgSetUp
  * 

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -1810,6 +1810,10 @@ inline bool ParseN2kBinaryStatus(const tN2kMsg &N2kMsg, unsigned char &DeviceBan
  * \brief Parse the content of a PGN 127502 (Switch Bank Control) message.
  * \ingroup group_msgParsers
  * 
+ * Review \ref N2kGetStatusOnBinaryStatus and the documentation of tN2kOnOff
+ * for information on how to process the bank status data returned by this
+ * function.
+ * 
  * \note This PGN is deprecated by NMEA and modern switch bank devices may
  *       well not support it, favouring PGN 126208 Command Group Function.
  *  
@@ -1821,7 +1825,6 @@ inline bool ParseN2kBinaryStatus(const tN2kMsg &N2kMsg, unsigned char &DeviceBan
  * \param BankStatus          The binary status component of the switchbank
  *                            control containing the commanded state of channels
  *                            on the target switchbank.
- *                            \ref N2kGetStatusOnBinaryStatus
  * 
  * \return true               Parsing of PGN Message successful
  * \return false              Parsing of PGN Message aborted
@@ -1851,8 +1854,13 @@ inline bool ParseN2kSwitchbankControl(const tN2kMsg &N2kMsg, unsigned char &Targ
  * channels which you intend to operate. Channels in which you have no
  * interest should not be commanded but set not available.
  * 
- * Review \ref N2kSetStatusOnBinaryStatus and the documentation of tN2kOnOff
- * for information on how to set up bank status.
+ * Review \ref N2kResetBinaryStatus, \ref N2kSetStatusOnBinaryStatus and the
+ * documentation of tN2kOnOff for information on how to set up bank status.
+ * 
+ * Remember as well, that transmission of a PGN 127502 message is equivalent
+ * to issuing a command, so do not send the same message repeatdly: once should
+ * be enough. You can always check that the target switchbank has responded
+ * by checking its PGN 127501 broadcasts.
  * 
  * \note This PGN is deprecated by NMEA and modern switch bank devices may
  *       well not support it, favouring PGN 126208 Command Group Function.

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -1807,9 +1807,12 @@ inline bool ParseN2kBinaryStatus(const tN2kMsg &N2kMsg, unsigned char &DeviceBan
 }
 
 /************************************************************************//**
- * \brief Parse the content of a PGN 127502 (Switch Bank Control) message
+ * \brief Parse the content of a PGN 127502 (Switch Bank Control) message.
  * \ingroup group_msgParsers
  * 
+ * \note This PGN is deprecated by NMEA and modern switch bank devices may
+ *       well not support it, favouring PGN 126208 Command Group Function.
+ *  
  * \param N2kMsg              Reference to the N2kMsg object to be parsed. If
  *                            this contains a valid PGN 127502 message then
  *                            the following return values will be set. 
@@ -1842,13 +1845,24 @@ inline bool ParseN2kSwitchbankControl(const tN2kMsg &N2kMsg, unsigned char &Targ
  * 
  * Command channel states on a remote switch bank. Up to 28 remote binary
  * states can be controlled.
+ * 
+ * When you create a tN2kBinaryStatus object for use with this function
+ * you should ensure that you only command (that is set ON or OFF) those
+ * channels which you intend to operate. Channels in which you have no
+ * interest should not be commanded but set not available.
+ * 
+ * Review \ref N2kSetStatusOnBinaryStatus and the documentation of tN2kOnOff
+ * for information on how to set up bank status.
+ * 
+ * \note This PGN is deprecated by NMEA and modern switch bank devices may
+ *       well not support it, favouring PGN 126208 Command Group Function.
  *
  * \param N2kMsg              Reference to an N2kMsg Object which will be
  *                            configured for sending on the NMEA bus. 
  * \param DeviceBankInstance  Instance number of the target switchbank (i.e.
  *                            the device to be controlled).
  * \param BankStatus          Full bank status containing the channel states
- *                            to to be commanded on the remote switchbank.
+ *                            to be commanded on the remote switchbank.
  *                            \ref N2kGetStatusOnBinaryStatus
  */
 void SetN2kPGN127502(tN2kMsg &N2kMsg, unsigned char TargetBankInstance, tN2kBinaryStatus BankStatus);


### PR DESCRIPTION
Hello again Timo. Hope you are well.

I wondered if you wanted to add some basic support for PGN 127502?

I'm just preparing some code from Signal K for a Teensy and realised there was a gap in the library. The code for PGN 1275012 is pretty much identical to that which already in place for PGN 127501, so I have really just done a cut and paste which adds:

ParseN2kPGN127502() and an alias ParseN2kSwitchbankControl()
SetN2kPGN127502() and an alias SetN2kSwitchbankControl()

Not tested yet (I've run out of Teensies and am awaiting availability), but the message formats for 127501 and 127502 are essentially identical, so (famous last words!) I'm pretty confident.

Best wishes,

Paul

