### PR TITLE
ParseN2kPGN129029: Don't leave output variables unset.

### DIFF
--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -1186,6 +1186,10 @@ bool ParseN2kPGN129029(const tN2kMsg &N2kMsg, unsigned char &SID, uint16_t &Days
     // Note that we return real number of stations, but we only have variabes for one.
     vi=N2kMsg.Get2ByteUInt(Index); ReferenceStationType=(tN2kGNSStype)(vi & 0x0f); ReferenceSationID=(vi>>4);
     AgeOfCorrection=N2kMsg.Get2ByteUDouble(0.01,Index);
+  } else {
+    ReferenceStationType = N2kGNSSt_GPS;
+    ReferenceSationID = N2kInt16NA;
+    AgeOfCorrection = N2kDoubleNA;
   }
 
   return true;

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -1186,10 +1186,6 @@ bool ParseN2kPGN129029(const tN2kMsg &N2kMsg, unsigned char &SID, uint16_t &Days
     // Note that we return real number of stations, but we only have variabes for one.
     vi=N2kMsg.Get2ByteUInt(Index); ReferenceStationType=(tN2kGNSStype)(vi & 0x0f); ReferenceSationID=(vi>>4);
     AgeOfCorrection=N2kMsg.Get2ByteUDouble(0.01,Index);
-  } else {
-    ReferenceStationType = GNSStype;
-    ReferenceSationID = N2kInt16NA;
-    AgeOfCorrection = N2kDoubleNA;
   }
 
   return true;

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -1186,6 +1186,10 @@ bool ParseN2kPGN129029(const tN2kMsg &N2kMsg, unsigned char &SID, uint16_t &Days
     // Note that we return real number of stations, but we only have variabes for one.
     vi=N2kMsg.Get2ByteUInt(Index); ReferenceStationType=(tN2kGNSStype)(vi & 0x0f); ReferenceSationID=(vi>>4);
     AgeOfCorrection=N2kMsg.Get2ByteUDouble(0.01,Index);
+  } else {
+    ReferenceStationType = GNSStype;
+    ReferenceSationID = N2kInt16NA;
+    AgeOfCorrection = N2kDoubleNA;
   }
 
   return true;

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -3157,6 +3157,11 @@ inline void SetN2kGNSS(tN2kMsg &N2kMsg, unsigned char SID, uint16_t DaysSince197
  * This parameter group conveys a comprehensive set of Global Navigation 
  * Satellite System (GNSS) parameters, including position information.
  * 
+ * The parameters passed to ReferenceStationType, ReferenceStationID and AgeOfCorrection
+ * are unchanged when there are no reference stations present in the message.
+ * One way to handle it is to initialize the variables passed to N2kGNSSt_GPS,
+ * N2kInt16NA and N2kDoubleNA respectively, before calling this function.
+ *
  * \param N2kMsg      Reference to a N2kMsg Object, 
  * \param SID         Sequence ID. If your device is e.g. boat speed and
  *                    heading at same time, you can set same SID for

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -3157,10 +3157,9 @@ inline void SetN2kGNSS(tN2kMsg &N2kMsg, unsigned char SID, uint16_t DaysSince197
  * This parameter group conveys a comprehensive set of Global Navigation 
  * Satellite System (GNSS) parameters, including position information.
  * 
- * The parameters passed to ReferenceStationType, ReferenceStationID and AgeOfCorrection
- * are unchanged when there are no reference stations present in the message.
- * One way to handle it is to initialize the variables passed to N2kGNSSt_GPS,
- * N2kInt16NA and N2kDoubleNA respectively, before calling this function.
+ * The parameters passed to ReferenceStationType, ReferenceStationID and
+ * AgeOfCorrection are set to N2kGNSSt_GPS, N2kInt16NA and N2kDoubleNA
+ * respectively, when there are no reference stations present in the message.
  *
  * \param N2kMsg      Reference to a N2kMsg Object, 
  * \param SID         Sequence ID. If your device is e.g. boat speed and


### PR DESCRIPTION
Rationale: This way there are less surprises for the caller.