### PR TITLE
Change padding of N2k Str var Callsign, Vendor, and Destination 

### DIFF
--- a/Documents/src/changes.md
+++ b/Documents/src/changes.md
@@ -1,6 +1,11 @@
 # Changes to the Library {#changes}
 \tableofcontents
 
+## 23.02.2024
+
+- Compatibility change: Parsers ParseN2kPGN129809, ParseN2kPGN129810 and ParseN2kPGN129794 parameter list 
+	Added bufer length fields for Name, Callsign, and Destination
+
 ## 09.02.2024
 
 - Fix multiple spelling errors in comments. Thanks to garaminowicz.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=NMEA2000
-version=4.20.3
+version=4.21.1
 author=Timo Lappalainen
 maintainer=Kave Oy <www.kave.fi>
 sentence=NMEA 2000 library for building compatible devices for NMEA 2000 bus.

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -1621,8 +1621,8 @@ void SetN2kPGN129794(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, u
     N2kMsg.AddByte((Repeat & 0x03)<<6 | (MessageID & 0x3f));
     N2kMsg.Add4ByteUInt(UserID);
     N2kMsg.Add4ByteUInt(IMOnumber);
-    N2kMsg.AddStr(Callsign, 7);
-    N2kMsg.AddStr(Name, 20);
+    N2kMsg.AddStr(Callsign, 7, false, '@');
+    N2kMsg.AddStr(Name, 20, false, '@');
     N2kMsg.AddByte(VesselType);
     N2kMsg.Add2ByteDouble(Length, 0.1);
     N2kMsg.Add2ByteDouble(Beam, 0.1);
@@ -1631,16 +1631,16 @@ void SetN2kPGN129794(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, u
     N2kMsg.Add2ByteUInt(ETAdate);
     N2kMsg.Add4ByteUDouble(ETAtime, 0.0001);
     N2kMsg.Add2ByteDouble(Draught, 0.01);
-    N2kMsg.AddStr(Destination, 20);
+    N2kMsg.AddStr(Destination, false, 20, '@');
     N2kMsg.AddByte((DTE & 0x01)<<6 | (GNSStype & 0x0f)<<2 | (AISversion & 0x03));
     N2kMsg.AddByte(0xe0 | (AISinfo & 0x1f));
     N2kMsg.AddByte(0xff);
 }
 
 bool ParseN2kPGN129794(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
-                        uint32_t &IMOnumber, char *Callsign, char *Name, uint8_t &VesselType, double &Length,
+                        uint32_t &IMOnumber, char *Callsign, size_t CallsignBufSize, char *Name, size_t NameBufSize,uint8_t &VesselType, double &Length,
                         double &Beam, double &PosRefStbd, double &PosRefBow, uint16_t &ETAdate, double &ETAtime,
-                        double &Draught, char *Destination, tN2kAISVersion &AISversion, tN2kGNSStype &GNSStype,
+                        double &Draught, char *Destination, size_t DestinationBufSize, tN2kAISVersion &AISversion, tN2kGNSStype &GNSStype,
                         tN2kAISDTE &DTE, tN2kAISTransceiverInformation &AISinfo)
 {
     if (N2kMsg.PGN!=129794L) return false;
@@ -1651,8 +1651,8 @@ bool ParseN2kPGN129794(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat 
     vb=N2kMsg.GetByte(Index); MessageID=(vb & 0x3f); Repeat=(tN2kAISRepeat)(vb>>6 & 0x03);
     UserID=N2kMsg.Get4ByteUInt(Index);
     IMOnumber=N2kMsg.Get4ByteUInt(Index);
-    N2kMsg.GetStr(Callsign, 7, Index);
-    N2kMsg.GetStr(Name, 20, Index);
+    N2kMsg.GetStr(CallsignBufSize, Callsign, 7, '@', Index);
+    N2kMsg.GetStr(NameBufSize, Name, 20, '@', Index);
     VesselType=N2kMsg.GetByte(Index);
     Length=N2kMsg.Get2ByteDouble(0.1, Index);
     Beam=N2kMsg.Get2ByteDouble(0.1, Index);
@@ -1661,7 +1661,7 @@ bool ParseN2kPGN129794(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat 
     ETAdate=N2kMsg.Get2ByteUInt(Index);
     ETAtime=N2kMsg.Get4ByteUDouble(0.0001, Index);
     Draught=N2kMsg.Get2ByteDouble(0.01, Index);
-    N2kMsg.GetStr(Destination, 20, Index);
+    N2kMsg.GetStr(DestinationBufSize, Destination, 20, '@', Index);
     vb=N2kMsg.GetByte(Index); AISversion=(tN2kAISVersion)(vb & 0x03); GNSStype=(tN2kGNSStype)(vb>>2 & 0x0f); DTE=(tN2kAISDTE)(vb>>6 & 0x01);
     vb=N2kMsg.GetByte(Index); AISinfo=(tN2kAISTransceiverInformation)(vb & 0x1f);
 
@@ -1676,10 +1676,10 @@ void SetN2kPGN129809(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, u
     N2kMsg.Priority=6;
     N2kMsg.AddByte((Repeat & 0x03)<<6 | (MessageID & 0x3f));
     N2kMsg.Add4ByteUInt(UserID);
-    N2kMsg.AddStr(Name, 20);
+    N2kMsg.AddStr(Name, 20, false, '@');
 }
 
-bool ParseN2kPGN129809(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID, char *Name)
+bool ParseN2kPGN129809(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID, char *Name, size_t NameBufSize)
 {
     if (N2kMsg.PGN!=129809L) return false;
 
@@ -1688,7 +1688,7 @@ bool ParseN2kPGN129809(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat 
 
     vb=N2kMsg.GetByte(Index); MessageID=(vb & 0x3f); Repeat=(tN2kAISRepeat)(vb>>6 & 0x03);
     UserID=N2kMsg.Get4ByteUInt(Index);
-    N2kMsg.GetStr(Name, 20, Index);
+    N2kMsg.GetStr(NameBufSize, Name, 20, '@', Index);
 
     return true;
 }
@@ -1704,8 +1704,8 @@ void SetN2kPGN129810(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, u
     N2kMsg.AddByte((Repeat & 0x03)<<6 | (MessageID & 0x3f));
     N2kMsg.Add4ByteUInt(UserID);
     N2kMsg.AddByte(VesselType);
-    N2kMsg.AddStr(Vendor, 7);
-    N2kMsg.AddStr(Callsign, 7);
+    N2kMsg.AddStr(Vendor, 7, false, '@');
+    N2kMsg.AddStr(Callsign, 7, false, '@');
     N2kMsg.Add2ByteUDouble(Length, 0.1);
     N2kMsg.Add2ByteUDouble(Beam, 0.1);
     N2kMsg.Add2ByteUDouble(PosRefStbd, 0.1);
@@ -1715,7 +1715,7 @@ void SetN2kPGN129810(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, u
 }
 
 bool ParseN2kPGN129810(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
-                      uint8_t &VesselType, char *Vendor, char *Callsign, double &Length, double &Beam,
+                      uint8_t &VesselType, char *Vendor, size_t VendorBufSize, char *Callsign, size_t CallsignBufSize, double &Length, double &Beam,
                       double &PosRefStbd, double &PosRefBow, uint32_t &MothershipID)
 {
     if (N2kMsg.PGN!=129810L) return false;
@@ -1726,8 +1726,8 @@ bool ParseN2kPGN129810(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat 
     vb=N2kMsg.GetByte(Index); MessageID=(vb & 0x3f); Repeat=(tN2kAISRepeat)(vb>>6 & 0x03);
     UserID=N2kMsg.Get4ByteUInt(Index);
     VesselType=N2kMsg.GetByte(Index);
-    N2kMsg.GetStr(Vendor, 7, Index);
-    N2kMsg.GetStr(Callsign, 7, Index);
+    N2kMsg.GetStr(VendorBufSize, Vendor, 7, '@', Index);
+    N2kMsg.GetStr(CallsignBufSize, Callsign, 7, '@', Index);
     Length = N2kMsg.Get2ByteUDouble(0.1, Index);
     Beam = N2kMsg.Get2ByteUDouble(0.1, Index);
     PosRefStbd = N2kMsg.Get2ByteUDouble(0.1, Index);

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -4360,11 +4360,13 @@ inline void SetN2kAISClassAStatic(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRep
  *                        [1 .. 999999999]; 0 = not available = default  
  *                        Not applicable to SAR aircraft
  * \param Callsign        Call Sign - 7x -> 6 bit ASCII characters,
+ * \param CallsignBufSize size of Callsign buffer
  * \param Name            Name of the vessel; 
  *                        Maximum 20 characters 6 bit ASCII;
  *                        For SAR aircraft, it should be set
  *                        to “SAR AIRCRAFT NNNNNNN” where NNNNNNN equals
  *                        the aircraft registration number
+ * \param NameBufSize     size of Name buffer
  * \param VesselType      Vessel Type 
  *                        0 = not available or no ship = default
  *                        1-99 = as defined in § 3.3.2
@@ -4380,6 +4382,7 @@ inline void SetN2kAISClassAStatic(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRep
  * \param Draught         Maximum present static draught
  * \param Destination     Destination - 
  *                        Maximum 20 characters using 6-bit ASCII  
+ * \param DestinationBufSize size of Destination buffer
  * \param AISversion      AIS version, see \ref tN2kAISVersion
  * \param GNSStype        Type of GNSS, see \ref tN2kGNSStype
  * \param DTE             Data terminal equipment (DTE) ready
@@ -4393,9 +4396,9 @@ inline void SetN2kAISClassAStatic(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRep
  * 
  */
 bool ParseN2kPGN129794(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
-                        uint32_t &IMOnumber, char *Callsign, char *Name, uint8_t &VesselType, double &Length,
+                        uint32_t &IMOnumber, char *Callsign, size_t CallsignBufSize, char *Name, size_t NameBufSize, uint8_t &VesselType, double &Length,
                         double &Beam, double &PosRefStbd, double &PosRefBow, uint16_t &ETAdate, double &ETAtime,
-                        double &Draught, char *Destination, tN2kAISVersion &AISversion, tN2kGNSStype &GNSStype,
+                        double &Draught, char *Destination, size_t DestinationBufSize, tN2kAISVersion &AISversion, tN2kGNSStype &GNSStype,
                         tN2kAISDTE &DTE, tN2kAISTransceiverInformation &AISinfo);
 
 /************************************************************************//**
@@ -4407,12 +4410,12 @@ bool ParseN2kPGN129794(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat 
  * of the source code. See parameter details on \ref ParseN2kPGN129794 
  */
 inline bool ParseN2kAISClassAStatic(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
-                        uint32_t & IMOnumber, char *Callsign, char *Name, uint8_t &VesselType, double &Length,
+                        uint32_t & IMOnumber, char *Callsign, size_t CallsignBufSize, char *Name, size_t NameBufSize, uint8_t &VesselType, double &Length,
                         double &Beam, double &PosRefStbd, double &PosRefBow, uint16_t &ETAdate, double &ETAtime,
-                        double &Draught, char *Destination, tN2kAISVersion &AISversion, tN2kGNSStype &GNSStype,
+                        double &Draught, char *Destination, size_t DestinationBufSize, tN2kAISVersion &AISversion, tN2kGNSStype &GNSStype,
                         tN2kAISDTE &DTE, tN2kAISTransceiverInformation &AISinfo) {
-  return ParseN2kPGN129794(N2kMsg, MessageID, Repeat, UserID, IMOnumber, Callsign, Name, VesselType, Length,
-                          Beam, PosRefStbd, PosRefBow, ETAdate, ETAtime, Draught, Destination, AISversion,
+  return ParseN2kPGN129794(N2kMsg, MessageID, Repeat, UserID, IMOnumber, Callsign, CallsignBufSize, Name, NameBufSize, VesselType, Length,
+                          Beam, PosRefStbd, PosRefBow, ETAdate, ETAtime, Draught, Destination, DestinationBufSize,AISversion,
                           GNSStype, DTE, AISinfo);
 }
 
@@ -4476,11 +4479,12 @@ inline void SetN2kAISClassBStaticPartA(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kA
  *                        For SAR aircraft, it should be set
  *                        to “SAR AIRCRAFT NNNNNNN” where NNNNNNN equals
  *                        the aircraft registration number
+ * \param NameBufSize  size of Name buffer
  * 
  * \return true     Parsing of PGN Message successful
  * \return false    Parsing of PGN Message aborted
  */
-bool ParseN2kPGN129809(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID, char *Name);
+bool ParseN2kPGN129809(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID, char *Name, size_t NameBufSize);
 
 /************************************************************************//**
  * \brief Parsing the content of a "AIS static data class B part A" 
@@ -4490,8 +4494,8 @@ bool ParseN2kPGN129809(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat 
  * Alias of PGN 129809. This alias was introduced to improve the readability
  * of the source code. See parameter details on \ref ParseN2kPGN129809 
  */
-inline bool ParseN2kAISClassBStaticPartA(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID, char *Name) {
-  return ParseN2kPGN129809(N2kMsg, MessageID, Repeat, UserID, Name);
+inline bool ParseN2kAISClassBStaticPartA(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID, char *Name, size_t NameBufSize) {
+  return ParseN2kPGN129809(N2kMsg, MessageID, Repeat, UserID, Name, NameBufSize);
 }
 
 /************************************************************************//**
@@ -4573,7 +4577,9 @@ inline void SetN2kAISClassBStaticPartB(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kA
  *                        Not applicable to SAR aircraft
  * \param Vendor          Unique identification of the Unit by a number as
  *                        defined by the manufacturer
+ * \param VendorBufSize   size of Vendor buffer
  * \param Callsign        Call Sign - 7x -> 6 bit ASCII characters
+ * \param CallsignBufSize size of Callsign buffer
  * \param Length          Length/Diameter in meters
  * \param Beam            Beam/Diameter in meters
  * \param PosRefStbd      Position Reference Point from Starboard 
@@ -4585,7 +4591,7 @@ inline void SetN2kAISClassBStaticPartB(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kA
  * 
  */
 bool ParseN2kPGN129810(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
-                      uint8_t &VesselType, char *Vendor, char *Callsign, double &Length, double &Beam,
+                      uint8_t &VesselType, char *Vendor, size_t VendorBufSize, char *Callsign, size_t CallsignBufSize,double &Length, double &Beam,
                       double &PosRefStbd, double &PosRefBow, uint32_t &MothershipID);
 
 /************************************************************************//**
@@ -4597,9 +4603,9 @@ bool ParseN2kPGN129810(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat 
  * of the source code. See parameter details on \ref ParseN2kPGN129810 
  */
 inline bool ParseN2kAISClassBStaticPartB(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
-                      uint8_t &VesselType, char *Vendor, char *Callsign, double &Length, double &Beam,
+		      uint8_t &VesselType, char *Vendor, size_t VendorBufSize, char *Callsign, size_t CallsignBufSize, double &Length, double &Beam,
                       double &PosRefStbd, double &PosRefBow, uint32_t &MothershipID) {
-  return ParseN2kPGN129810(N2kMsg, MessageID, Repeat, UserID, VesselType, Vendor, Callsign,
+  return ParseN2kPGN129810(N2kMsg, MessageID, Repeat, UserID, VesselType, Vendor, VendorBufSize, Callsign, CallsignBufSize,
                                 Length, Beam, PosRefStbd, PosRefBow, MothershipID);
 }
 

--- a/src/N2kMsg.cpp
+++ b/src/N2kMsg.cpp
@@ -209,8 +209,8 @@ void tN2kMsg::AddByte(unsigned char v) {
 }
 
 //*****************************************************************************
-void tN2kMsg::AddStr(const char *str, int len, bool UsePgm) {
-  SetBufStr(str,len,DataLen,Data,UsePgm,0xff);
+void tN2kMsg::AddStr(const char *str, int len, bool UsePgm, unsigned char fillChar) {
+  SetBufStr(str,len,DataLen,Data,UsePgm,fillChar);
 }
 
 //*****************************************************************************

--- a/src/N2kMsg.h
+++ b/src/N2kMsg.h
@@ -946,8 +946,9 @@ public:
   * \param str   String as pointer to a char array
   * \param len   Length of the string
   * \param UsePgm {bool} use the pgm_read_byte function
+  * \param fillChar character to for padding at end of strings
   */
-  void AddStr(const char *str, int len, bool UsePgm=false);
+  void AddStr(const char *str, int len, bool UsePgm=false, unsigned char fillChar=0xff);
 
  /************************************************************************//**
   * \brief Add string value to the buffer


### PR DESCRIPTION

Change padding of N2k Str vars Callsign, Vendor, and Destination from 0xff to @ for 129809, 129810, and 129794 as per N2k spec