### PR TITLE
Add new PGNs and expand AIS PGNs

### DIFF
--- a/Documents/src/changes.md
+++ b/Documents/src/changes.md
@@ -2,6 +2,11 @@
 \tableofcontents
 
 ## 25.03.2024
+- Added PGN 127510
+- Added PGN 127750
+- Modidified AIS PGN PGN 129038, 129039, 129794, 129809, and 129810 to include AIS Transceiver Info and SID (where applicable)
+
+## 25.03.2024
 
 - Fix for ParseN2kPGN129810 parameter list.
 - Fixed SetN2kPGN129810 - AIS spare must be 0

--- a/library.json
+++ b/library.json
@@ -13,7 +13,7 @@
     "url": "http://www.kave.fi",
     "maintainer": true
   },
-  "version": "4.21.3",
+  "version": "4.21.4",
   "license": "MIT",
   "frameworks": "*",
   "platforms": "*"

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=NMEA2000
-version=4.21.3
+version=4.21.4
 author=Timo Lappalainen
 maintainer=Kave Oy <www.kave.fi>
 sentence=NMEA 2000 library for building compatible devices for NMEA 2000 bus.

--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -1796,7 +1796,7 @@ void SetN2kPGN129810(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, u
     N2kMsg.Add2ByteUDouble(PosRefBow, 0.1);
     N2kMsg.Add4ByteUInt(MothershipID);
     N2kMsg.AddByte(0x03);  // Reserved + AIS spare
-    N2kMsg.AddByte(0xe3 | (AISInfo & 0x1f));  // AIS Tranceiver info + Channel B VDL transmission + reserved
+    N2kMsg.AddByte(0xe0 | (AISInfo & 0x1f));  // AIS Tranceiver info +  reserved
     N2kMsg.AddByte(SID);
 }
 

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -4790,7 +4790,7 @@ inline bool ParseN2kAISClassBStaticPartA(const tN2kMsg &N2kMsg, uint8_t &Message
  */
 void SetN2kPGN129810(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, uint32_t UserID,
 		     uint8_t VesselType, const char *Vendor, const char *Callsign, double Length, double Beam,
-		     double PosRefStbd, double PosRefBow, uint32_t MothershipID, tN2kAISTransceiverInformation AISInfo=N2kaischannel_A_VDL_reception, uint8_t SID=0xff);
+		     double PosRefStbd, double PosRefBow, uint32_t MothershipID, tN2kAISTransceiverInformation AISInfo=N2kaischannel_B_VDL_reception, uint8_t SID=0xff);
 
 /************************************************************************//**
  * \brief Setting up Message "AIS static data class B part B" - PGN 129810

--- a/src/N2kMessages.h
+++ b/src/N2kMessages.h
@@ -2036,7 +2036,7 @@ void SetN2kPGN127507(tN2kMsg &N2kMsg, unsigned char Instance, unsigned char Batt
  * 
  * Alias of PGN 127507. This alias was introduced to improve the readability
  * of the source code. See parameter details on \ref SetN2kPGN127507
-  */
+ */
 inline void SetN2kChargerStatus(tN2kMsg &N2kMsg, unsigned char Instance, unsigned char BatteryInstance,
                      tN2kChargeState ChargeState, tN2kChargerMode ChargerMode=N2kCM_Standalone,
                      tN2kOnOff Enabled=N2kOnOff_On, tN2kOnOff EqualizationPending=N2kOnOff_Unavailable, double EqualizationTimeRemaining=N2kDoubleNA) {
@@ -2157,6 +2157,85 @@ inline bool ParseN2kDCBatStatus(const tN2kMsg &N2kMsg, unsigned char &BatteryIns
 }
 
 /************************************************************************//**
+ * \brief Settingup PGN 127510 Message "Charger Configuration Status
+ * \ingroup group_msgSetUp
+ *
+ * \param N2kMsg              Reference to a N2kMsg Object,
+ *                            Output: NMEA2000 message ready to be send.
+ * \param ChargerInsance              ChargerIntance
+ * \param BatteryInstance             BatteryInstance
+ * \param Charger Enable/Disable      \ref tN2kOnOff
+ * \param ChargeCurrentLimit          CurrentLimit in % range 0-252 resolution 1%
+ * \param CharginAlgorithm            \ref tN2kChargingAlgorithm
+ * \param ChargerMode                 \ref tN2kChargerMode
+ * \param BatteryTemperature          Battery temp when no seonsor
+ * \param Equalization Enable/Disable \ref N2kOnOff.  Equalize one time enable/disable
+ * \param OverChargeEnable            \ref N2kOnOff.  Enable/Disable over charge
+ * \param EqualizationTimeRemaining   seconds
+ */
+void SetN2kPGN127510(tN2kMsg &N2kMsg, unsigned char ChargerInsance, unsigned char BatteryInstance, tN2kOnOff Enable=N2kOnOff_On,
+                     unsigned char ChargeCurrentLimit=N2kUInt8NA, tN2kChargingAlgorithm ChargingAlgorithm=N2kCA_3State, tN2kChargerMode ChargerMode=N2kCM_Standalone,
+		     tBattTempNoSensor BatteryTemperature=N2kBT_NotAvailable, tN2kOnOff EqualizationEnabled=N2kOnOff_Off,
+		     tN2kOnOff OverChargeEnable=N2kOnOff_Off, uint16_t  EqualizationTimeRemaining=0);
+
+/************************************************************************//**
+ * \brief Setting up Message "Charger Configurationn Status" - PGN 127510
+ * \ingroup group_msgSetUp
+ *
+ * Alias of PGN 127510. This alias was introduced to improve the readability
+ * of the source code. See parameter details on \ref SetN2kPGN127510
+ */
+inline void SetN2kChargerConf(tN2kMsg &N2kMsg, unsigned char ChargerInsance, unsigned char BatteryInstance, tN2kOnOff Enable=N2kOnOff_On,
+			      unsigned char ChargeCurrentLimit=N2kUInt8NA, tN2kChargingAlgorithm ChargingAlgorithm=N2kCA_3State, tN2kChargerMode ChargerMode=N2kCM_Standalone,
+			      tBattTempNoSensor BatteryTemperature=N2kBT_NotAvailable,
+			      tN2kOnOff EqualizationEnabled=N2kOnOff_Off, tN2kOnOff OverChargeEnable=N2kOnOff_Off, uint16_t EqualizationTimeRemaining=0) {
+   SetN2kPGN127510(N2kMsg,ChargerInsance,BatteryInstance,Enable,ChargeCurrentLimit,ChargingAlgorithm,ChargerMode,BatteryTemperature,
+                     EqualizationEnabled,OverChargeEnable,EqualizationTimeRemaining);
+}
+
+/************************************************************************//**
+ * \brief Parsing the content of message PGN 127510  "Charger Configuation  Status"
+ * \ingroup group_msgParsers
+ *
+ * Any device capable of charing a battery can transmit this
+ *
+ * \param N2kMsg       Reference to a N2kMsg Object,
+ *                     Output: NMEA2000 message ready to be send.
+ *
+ * \param ChargerInsance              ChargerIntance
+ * \param BatteryInstance             BatteryInstance
+ * \param Charger Enable/Disable      \ref tN2kOnOff
+ * \param ChargeCurrentLimit          CurrentLimit in % range 0-252 resolution 1%
+ * \param CharginAlgorithm            \ref tN2kChargingAlgorithm
+ * \param ChargerMode                 \ref tN2kChargerMode
+ * \param BatteryTemperature          Battery temp when no seonsor
+ * \param Equalization Enable/Disable \ref N2kOnOff.  Equalize one time enable/disable
+ * \param OverChargeEnable            \ref N2kOnOff.  Enable/Disable over charge
+ * \param EqualizationTimeRemaining   seconds
+ *
+ * \return true     Parsing of PGN Message successful
+ * \return false    Parsing of PGN Message aborted
+ */
+bool ParseN2kPGN127510(const tN2kMsg &N2kMsg, unsigned char &ChargerInsance, unsigned char &BatteryInstance, tN2kOnOff &Enable,
+                     unsigned char &ChargeCurrentLimit, tN2kChargingAlgorithm  &ChargingAlgorithm, tN2kChargerMode &ChargerMode, tBattTempNoSensor &BatteryTemperature,
+                                tN2kOnOff &EqualizationEnabled, tN2kOnOff &OverChargeEnable, uint16_t &EqualizationTimeRemaining);
+
+/************************************************************************//**
+ * \brief Setting up Message "Charger Configurationn Status" - PGN 127510
+ * \ingroup group_msgParsers
+ *
+ * Alias of PGN 127510. This alias was introduced to improve the readability
+ * of the source code. See parameter details on \ref ParseN2kPGN127510
+ */
+inline bool ParseN2kChargerConf(const tN2kMsg &N2kMsg, unsigned char &ChargerInsance, unsigned char &BatteryInstance, tN2kOnOff &Enable,
+                     unsigned char &ChargeCurrentLimit, tN2kChargingAlgorithm &ChargingAlgorithm, tN2kChargerMode &ChargerMode, tBattTempNoSensor &BatteryTemperature,
+                                tN2kOnOff &EqualizationEnabled, tN2kOnOff &OverChargeEnable, uint16_t &EqualizationTimeRemaining) {
+        return ParseN2kPGN127510(N2kMsg,ChargerInsance,BatteryInstance,Enable,ChargeCurrentLimit,ChargingAlgorithm,ChargerMode,BatteryTemperature,
+                     EqualizationEnabled,OverChargeEnable,EqualizationTimeRemaining);
+}
+
+
+/************************************************************************//**
  * \brief Setting up PGN 127513 Message "Battery Configuration Status"
  * \ingroup group_msgSetUp
  * 
@@ -2186,7 +2265,7 @@ void SetN2kPGN127513(tN2kMsg &N2kMsg, unsigned char BatInstance, tN2kBatType Bat
  * 
  * Alias of PGN 127513. This alias was introduced to improve the readability
  * of the source code. See parameter details on \ref SetN2kPGN127513
-  */
+ */
 inline void SetN2kBatConf(tN2kMsg &N2kMsg, unsigned char BatInstance, tN2kBatType BatType, tN2kBatEqSupport SupportsEqual,
                      tN2kBatNomVolt BatNominalVoltage, tN2kBatChem BatChemistry, double BatCapacity, int8_t BatTemperatureCoefficient,
 				double PeukertExponent, int8_t ChargeEfficiencyFactor) {
@@ -2212,7 +2291,7 @@ inline void SetN2kBatConf(tN2kMsg &N2kMsg, unsigned char BatInstance, tN2kBatTyp
  * \param BatTemperatureCoefficient Battery temperature coefficient in %
  * \param PeukertExponent      Peukert Exponent
  * \param ChargeEfficiencyFactor      Charge efficiency factor
- * 
+ *
  * \return true     Parsing of PGN Message successful
  * \return false    Parsing of PGN Message aborted
  *
@@ -2234,6 +2313,72 @@ inline bool ParseN2kBatConf(const tN2kMsg &N2kMsg, unsigned char &BatInstance, t
 				double &PeukertExponent, int8_t &ChargeEfficiencyFactor) {
 	return ParseN2kPGN127513(N2kMsg,BatInstance,BatType,SupportsEqual,BatNominalVoltage,BatChemistry,BatCapacity,BatTemperatureCoefficient,
 				PeukertExponent,ChargeEfficiencyFactor);
+}
+
+/*****************************************************************************//**
+ * \brief Converter (Inverter/Charger) Status
+ *          message PGN 127750
+ * \ingroup group_msgSetUp
+ *
+ *  Replaces PGN 127507
+ *
+ *  Provides state and status information about charger/inverters
+ *
+ * \param N2kMsg       Reference to a N2kMsg Object,
+ *                     Output: NMEA2000 message ready to be send.
+ * \param SID                   Sequence ID
+ * \param ConnectionNumber      Connection number
+ * \param OperatingState        \ref tN2kConvMode
+ * \param TemperatureState      \ref TemperatureState
+ * \param OverloadState         \ref tN2kOverloadState
+ * \param LowDCVoltageState     \ref tN2kDCVolgateState
+ * \param RippleState           \ref tN2kRippleState
+ */
+void SetN2kPGN127750(tN2kMsg &N2kMsg, unsigned char SID, unsigned char ConnectionNumber, tN2kConvMode OperatingState,
+                                  tN2kTemperatureState TemperatureState, tN2kOverloadState OverloadState, tN2kDCVolgateState LowDcVoltageState, tN2kRippleState RippleState);
+/*****************************************************************************//**
+ * \brief Converter (Inverter/Charger) Status
+ *          message PGN 127750
+ * \ingroup group_msgSetUp
+ *
+ * alias of PGN 127750. This alias was introduced to imporve the reliabilty
+ * of the source code. Seee parameter details on \ref SetN2kPGN127750
+ */
+inline void SetN2kDCConvStatus(tN2kMsg &N2kMsg, unsigned char SID, unsigned char ConnectionNumber, tN2kConvMode OperatingState,
+                                  tN2kTemperatureState TemperatureState, tN2kOverloadState OverloadState, tN2kDCVolgateState LowDcVoltageState, tN2kRippleState RippleState) {
+ SetN2kPGN127750(N2kMsg, SID, ConnectionNumber,OperatingState,TemperatureState,OverloadState,LowDcVoltageState,RippleState);
+}
+
+/************************************************************************//**
+ * \brief Parsing the content of message PGN 127750 Converter (Inverter/Charger) Status
+ * \ingroup group_msgParsers
+ *
+ * \param N2kMsg       Reference to a N2kMsg Object,
+ *                     Output: NMEA2000 message ready to be send.
+ * \param SID                   Sequence ID
+ * \param ConnectionNumber      Connection number
+ * \param OperatingState        \ref tN2kConvMode
+ * \param TemperatureState      \ref TemperatureState
+ * \param OverloadState         \ref tN2kOverloadState
+ * \param LowDCVoltageState     \ref tN2kDCVolgateState
+ * \param RippleState           \ref tN2kRippleState
+ *
+ * \return true     Parsing of PGN Message successful
+ * \return false    Parsing of PGN Message aborted
+ */
+bool ParseN2kPGN127750(const tN2kMsg &N2kMsg, unsigned char &SID, unsigned char &ConnectionNumber, tN2kConvMode &OperatingState,
+                                  tN2kTemperatureState &TemperatureState, tN2kOverloadState &OverloadState, tN2kDCVolgateState &LowDcVoltageState, tN2kRippleState &RippleState);
+
+/************************************************************************//**
+ * \brief Parsing the content of message PGN 127513 Converter (Inverter/Charger) Status
+ * \ingroup group_msgParsers
+ *
+ * aliaso of PGN 127750.  This alias was intruduced to improve the readability
+ * of the source code. See parameter details in \ref ParseN2kPGN127750
+ */
+inline bool ParseN2kDCConvStatus(const tN2kMsg &N2kMsg, unsigned char &SID, unsigned char &ConnectionNumber, tN2kConvMode &OperatingState,
+                                  tN2kTemperatureState &TemperatureState, tN2kOverloadState &OverloadState, tN2kDCVolgateState &LowDcVoltageState, tN2kRippleState &RippleState) {
+ return ParseN2kPGN127750(N2kMsg,SID,ConnectionNumber,OperatingState,TemperatureState,OverloadState,LowDcVoltageState,RippleState);
 }
 
 /************************************************************************//**
@@ -3251,12 +3396,15 @@ inline bool ParseN2kLocalOffset(const tN2kMsg &N2kMsg, uint16_t &DaysSince1970, 
  * \param Heading     heading
  * \param ROT         Rate of turn
  * \param NavStatus   Navigational status, see \ref tN2kAISNavStatus
+ * \param SID         Sequence identifier. In most cases you can use just 0xff for SID. See \ref secRefTermSID.
+ *                    The sequence identifier field is used to tie different PGNs data together to same
+ *                    sampling or calculation time.
  * 
  */
 void SetN2kPGN129038(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, uint32_t UserID, 
-                        double Latitude, double Longitude, bool Accuracy, bool RAIM, 
-                        uint8_t Seconds, double COG, double SOG, tN2kAISTransceiverInformation AISTransceiverInformation, 
-                        double Heading, double ROT, tN2kAISNavStatus NavStatus);
+                        double Latitude, double Longitude, bool Accuracy, bool RAIM,
+                        uint8_t Seconds, double COG, double SOG, tN2kAISTransceiverInformation AISTransceiverInformation,
+		     double Heading, double ROT, tN2kAISNavStatus NavStatus, uint8_t SID=0xff);
 /************************************************************************//**
  * \brief Setting up Message "AIS position reports for Class A" - PGN 129038
  * \ingroup group_msgSetUp
@@ -3265,11 +3413,11 @@ void SetN2kPGN129038(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, u
  * of the source code. See parameter details on \ref SetN2kPGN129038
   */
 inline void SetN2kAISClassAPosition(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, uint32_t UserID, 
-                        double Latitude, double Longitude, bool Accuracy, bool RAIM, 
-                        uint8_t Seconds, double COG, double SOG, tN2kAISTransceiverInformation AISTransceiverInformation,  
-                        double Heading, double ROT, tN2kAISNavStatus NavStatus) {
-  SetN2kPGN129038(N2kMsg, MessageID, Repeat, UserID, Latitude, Longitude, 
-                  Accuracy, RAIM, Seconds, COG, SOG, AISTransceiverInformation, Heading, ROT, NavStatus);
+				    double Latitude, double Longitude, bool Accuracy, bool RAIM,
+				    uint8_t Seconds, double COG, double SOG, tN2kAISTransceiverInformation AISTransceiverInformation,
+				    double Heading, double ROT, tN2kAISNavStatus NavStatus, uint8_t SID=0xff) {
+  SetN2kPGN129038(N2kMsg, MessageID, Repeat, UserID, Latitude, Longitude,
+                  Accuracy, RAIM, Seconds, COG, SOG, AISTransceiverInformation, Heading, ROT, NavStatus, SID);
 }
 
 /************************************************************************//**
@@ -3314,25 +3462,49 @@ inline void SetN2kAISClassAPosition(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISR
  * \param Heading     heading
  * \param ROT         Rate of turn
  * \param NavStatus   Navigational status, see \ref tN2kAISNavStatus
+ * \param AISTransceiverInformation    AIS transeiver info, see \ref tN2kAISTransceiverInformation
+ * \param SID         Sequence identifier. In most cases you can use just 0xff for SID. See \ref secRefTermSID.
+ *                    The sequence identifier field is used to tie different PGNs data together to same
+ *                    sampling or calculation time.
  * 
  * \return true     Parsing of PGN Message successful
  * \return false    Parsing of PGN Message aborted
  * 
  */
 bool ParseN2kPGN129038(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID, double &Latitude, double &Longitude,
-                        bool &Accuracy, bool &RAIM, uint8_t &Seconds, double &COG, double &SOG, double &Heading, double &ROT, tN2kAISNavStatus &NavStatus);
+		       bool &Accuracy, bool &RAIM, uint8_t &Seconds, double &COG, double &SOG, double &Heading, double &ROT, tN2kAISNavStatus &NavStatus,
+		       tN2kAISTransceiverInformation &AISTransceiverInformation, uint8_t &SID);
 
 /************************************************************************//**
- * \brief Parsing the content of a "AIS position reports for Class A" 
+ * \brief Parsing the content of a "AIS position reports for Class A"
  *        message - PGN 129038
  * \ingroup group_msgParsers
- * 
+ *
+ * Alias of PGN 129038. This alias was introduced to improve the readability
+ * of the source code. See parameter details on \ref ParseN2kPGN129038
+ */
+inline bool ParseN2kAISClassAPosition(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID, double &Latitude, double &Longitude,
+				      bool &Accuracy, bool &RAIM, uint8_t &Seconds, double &COG, double &SOG, double &Heading, double &ROT, tN2kAISNavStatus & NavStatus,
+				      tN2kAISTransceiverInformation &AISTransceiverInformation, uint8_t &SID) {
+  return ParseN2kPGN129038(N2kMsg, MessageID, Repeat, UserID, Latitude, Longitude, Accuracy, RAIM, Seconds, COG, SOG, Heading, ROT, NavStatus, AISTransceiverInformation, SID);
+}
+
+/************************************************************************//**
+ * \brief Parsing the content of a "AIS position reports for Class A"
+ *        message - PGN 129038
+ * \ingroup group_msgParsers
+ *
+ * \note Previous inline version for backwards compatibility, using temporary
+ * value to parse unused parameter
+ *
  * Alias of PGN 129038. This alias was introduced to improve the readability
  * of the source code. See parameter details on \ref ParseN2kPGN129038 
  */
 inline bool ParseN2kAISClassAPosition(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID, double &Latitude, double &Longitude,
-                        bool &Accuracy, bool &RAIM, uint8_t &Seconds, double &COG, double &SOG, double &Heading, double &ROT, tN2kAISNavStatus & NavStatus) {
-  return ParseN2kPGN129038(N2kMsg, MessageID, Repeat, UserID, Latitude, Longitude, Accuracy, RAIM, Seconds, COG, SOG, Heading, ROT, NavStatus);
+				      bool &Accuracy, bool &RAIM, uint8_t &Seconds, double &COG, double &SOG, double &Heading, double &ROT, tN2kAISNavStatus & NavStatus) {
+  tN2kAISTransceiverInformation AISInfo;
+  uint8_t SID;
+  return ParseN2kPGN129038(N2kMsg, MessageID, Repeat, UserID, Latitude, Longitude, Accuracy, RAIM, Seconds, COG, SOG, Heading, ROT, NavStatus, AISInfo, SID);
 }
 
 /************************************************************************//**
@@ -3401,9 +3573,8 @@ inline bool ParseN2kAISClassAPosition(const tN2kMsg &N2kMsg, uint8_t &MessageID,
  *                    - 0 = SOTDMA communication state follows
  *                    - 1 = ITDMA communication state follows
  *                    (always “1” for Class-B “CS”)
- * \param SID         Sequence identifier. In most cases you can use just 0xff for SID. See \ref secRefTermSID. \n
- *                    \n
- *                    The sequence identifier field is used to tie different PGNs data together to same 
+ * \param SID         Sequence identifier. In most cases you can use just 0xff for SID. See \ref secRefTermSID.
+ *                    The sequence identifier field is used to tie different PGNs data together to same
  *                    sampling or calculation time.
  * 
  */
@@ -3420,7 +3591,7 @@ void SetN2kPGN129039(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, u
  * 
  * Alias of PGN 129039. This alias was introduced to improve the readability
  * of the source code. See parameter details on \ref SetN2kPGN129039
-  */
+ */
 inline void SetN2kAISClassBPosition(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, uint32_t UserID,
                         double Latitude, double Longitude, bool Accuracy, bool RAIM,
                         uint8_t Seconds, double COG, double SOG, tN2kAISTransceiverInformation AISTransceiverInformation,
@@ -3440,13 +3611,13 @@ inline void SetN2kAISClassBPosition(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISR
  * 
  * Alias of PGN 129039. This alias was introduced to improve the readability
  * of the source code. See parameter details on \ref SetN2kPGN129039
-  */
+ */
 inline void SetN2kAISClassBPosition(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, uint32_t UserID,
-                        double Latitude, double Longitude, bool Accuracy, bool RAIM,
-                        uint8_t Seconds, double COG, double SOG, double Heading, tN2kAISUnit Unit,
-                        bool Display, bool DSC, bool Band, bool Msg22, tN2kAISMode Mode, bool State) {
+				    double Latitude, double Longitude, bool Accuracy, bool RAIM,
+				    uint8_t Seconds, double COG, double SOG, double Heading, tN2kAISUnit Unit,
+				    bool Display, bool DSC, bool Band, bool Msg22, tN2kAISMode Mode, bool State) {
   SetN2kPGN129039(N2kMsg, MessageID, Repeat, UserID, Latitude, Longitude, Accuracy, RAIM, Seconds,
-                    COG, SOG, N2kaischannel_A_VDL_reception, Heading, Unit, Display, DSC, Band, Msg22, Mode, State);
+		  COG, SOG, N2kaischannel_A_VDL_reception, Heading, Unit, Display, DSC, Band, Msg22, Mode, State);
 }
 
 /************************************************************************//**
@@ -3516,39 +3687,63 @@ inline void SetN2kAISClassBPosition(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISR
  *                    - 0 = SOTDMA communication state follows
  *                    - 1 = ITDMA communication state follows
  *                    (always “1” for Class-B “CS”)
+ * \param SID         Sequence identifier. In most cases you can use just 0xff for SID. See \ref secRefTermSID.
+ *                    The sequence identifier field is used to tie different PGNs data together to same
+ *                    sampling or calculation time.
  * 
  * \return true     Parsing of PGN Message successful
  * \return false    Parsing of PGN Message aborted
  * 
  */
 bool ParseN2kPGN129039(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
-                        double &Latitude, double &Longitude, bool &Accuracy, bool &RAIM, uint8_t &Seconds, double &COG,
-                        double &SOG, tN2kAISTransceiverInformation &AISTransceiverInformation, double &Heading,
-                        tN2kAISUnit &Unit, bool &Display, bool &DSC, bool &Band, bool &Msg22, tN2kAISMode &Mode, bool &State);
+		       double &Latitude, double &Longitude, bool &Accuracy, bool &RAIM, uint8_t &Seconds, double &COG,
+		       double &SOG, tN2kAISTransceiverInformation &AISTransceiverInformation, double &Heading,
+		       tN2kAISUnit &Unit, bool &Display, bool &DSC, bool &Band, bool &Msg22, tN2kAISMode &Mode, bool &State, uint8_t &SID);
 
 /************************************************************************//**
- * \brief Parsing the content of a "AIS position reports for Class B" 
+ * \brief Parsing the content of a "AIS position reports for Class B"
  *        message - PGN 129039
  * \ingroup group_msgParsers
- * 
+ *
  * (Latest inline version)
- * 
+ *
  * Alias of PGN 129039. This alias was introduced to improve the readability
- * of the source code. See parameter details on \ref ParseN2kPGN129039 
+ * of the source code. See parameter details on \ref ParseN2kPGN129039
  */
 inline bool ParseN2kAISClassBPosition(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
-                        double &Latitude, double &Longitude, bool &Accuracy, bool &RAIM,
-                        uint8_t &Seconds, double &COG, double &SOG, tN2kAISTransceiverInformation &AISTransceiverInformation,
-                        double &Heading, tN2kAISUnit &Unit, bool &Display, bool &DSC, bool &Band, bool &Msg22, tN2kAISMode &Mode,
-                        bool &State) {
-  return ParseN2kPGN129039(N2kMsg, MessageID, Repeat, UserID, Latitude, Longitude, Accuracy, RAIM, Seconds, COG, SOG, AISTransceiverInformation, Heading, Unit, Display, DSC, Band, Msg22, Mode, State);
+				      double &Latitude, double &Longitude, bool &Accuracy, bool &RAIM,
+				      uint8_t &Seconds, double &COG, double &SOG, tN2kAISTransceiverInformation &AISTransceiverInformation,
+				      double &Heading, tN2kAISUnit &Unit, bool &Display, bool &DSC, bool &Band, bool &Msg22, tN2kAISMode &Mode,
+				      bool &State, uint8_t &SID) {
+  return ParseN2kPGN129039(N2kMsg, MessageID, Repeat, UserID, Latitude, Longitude, Accuracy, RAIM, Seconds, COG, SOG, AISTransceiverInformation, Heading, Unit, Display, DSC, Band, Msg22, Mode, State, SID);
 }
 
 /************************************************************************//**
- * \brief Parsing the content of a "AIS position reports for Class B" 
+ * \brief Parsing the content of a "AIS position reports for Class B"
  *        message - PGN 129039
  * \ingroup group_msgParsers
- * 
+ *
+ * \note Previous inline version for backwards compatibility, using temporary
+ * value to parse unused parameter
+ *
+ * Alias of PGN 129039. This alias was introduced to improve the readability
+ * of the source code. See parameter details on \ref ParseN2kPGN129039
+ */
+inline bool ParseN2kAISClassBPosition(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
+				      double &Latitude, double &Longitude, bool &Accuracy, bool &RAIM,
+				      uint8_t &Seconds, double &COG, double &SOG, double &Heading, tN2kAISUnit &Unit,
+				      bool &Display, bool &DSC, bool &Band, bool &Msg22, tN2kAISMode &Mode, bool &State) {
+  tN2kAISTransceiverInformation AISTransceiverInformation; // for backwards compatibility
+  uint8_t SID;
+  return ParseN2kPGN129039(N2kMsg, MessageID, Repeat, UserID, Latitude, Longitude, Accuracy,
+			   RAIM, Seconds, COG, SOG, AISTransceiverInformation, Heading, Unit, Display, DSC, Band, Msg22, Mode, State, SID);
+}
+
+/************************************************************************//**
+ * \brief Parsing the content of a "AIS position reports for Class B"
+ *        message - PGN 129039
+ * \ingroup group_msgParsers
+ *
  * \note Previous inline version for backwards compatibility, using temporary
  * value to parse unused parameter
  * 
@@ -3556,12 +3751,12 @@ inline bool ParseN2kAISClassBPosition(const tN2kMsg &N2kMsg, uint8_t &MessageID,
  * of the source code. See parameter details on \ref ParseN2kPGN129039 
  */
 inline bool ParseN2kAISClassBPosition(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
-                        double &Latitude, double &Longitude, bool &Accuracy, bool &RAIM,
-                        uint8_t &Seconds, double &COG, double &SOG, double &Heading, tN2kAISUnit &Unit,
-                        bool &Display, bool &DSC, bool &Band, bool &Msg22, tN2kAISMode &Mode, bool &State) {
-  tN2kAISTransceiverInformation AISTransceiverInformation; // for backwards compatibility
+				      double &Latitude, double &Longitude, bool &Accuracy, bool &RAIM,
+				      uint8_t &Seconds, double &COG, double &SOG, tN2kAISTransceiverInformation &AISTransceiverInformation,
+				      double &Heading, tN2kAISUnit &Unit, bool &Display, bool &DSC, bool &Band, bool &Msg22, tN2kAISMode &Mode, bool &State) {
+  uint8_t SID;   // for backwards compatibility
   return ParseN2kPGN129039(N2kMsg, MessageID, Repeat, UserID, Latitude, Longitude, Accuracy,
-                            RAIM, Seconds, COG, SOG, AISTransceiverInformation, Heading, Unit, Display, DSC, Band, Msg22, Mode, State);
+			   RAIM, Seconds, COG, SOG, AISTransceiverInformation, Heading, Unit, Display, DSC, Band, Msg22, Mode, State, SID);
 }
 
 /************************************************************************//**
@@ -4317,12 +4512,13 @@ inline bool ParseN2kPGNSatellitesInView(const tN2kMsg& N2kMsg, uint8_t SVIndex, 
  *                        - 1 = not available = default
  * \param AISinfo         AIS Transceiver Information,
  *                        see \ref tN2kAISTransceiverInformation
+ * \param SID             Sequence ID used to bind two PGNs from the same source together. See \ref secRefTermSID.
  */
 void SetN2kPGN129794(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, uint32_t UserID,
-                        uint32_t IMOnumber, const char *Callsign, const char *Name, uint8_t VesselType, double Length,
-                        double Beam, double PosRefStbd, double PosRefBow, uint16_t ETAdate, double ETAtime,
-                        double Draught, const char *Destination, tN2kAISVersion AISversion, tN2kGNSStype GNSStype,
-                        tN2kAISDTE DTE, tN2kAISTransceiverInformation AISinfo);
+		     uint32_t IMOnumber, const char *Callsign, const char *Name, uint8_t VesselType, double Length,
+		     double Beam, double PosRefStbd, double PosRefBow, uint16_t ETAdate, double ETAtime,
+		     double Draught, const char *Destination, tN2kAISVersion AISversion, tN2kGNSStype GNSStype,
+		     tN2kAISDTE DTE, tN2kAISTransceiverInformation AISinfo=N2kaischannel_A_VDL_reception, uint8_t SID=0xff);
 
 /************************************************************************//**
  * \brief Setting up Message "AIS static data class A" - PGN 129794
@@ -4332,12 +4528,12 @@ void SetN2kPGN129794(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, u
  * of the source code. See parameter details on \ref SetN2kPGN129794
   */
 inline void SetN2kAISClassAStatic(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, uint32_t UserID,
-                        uint32_t IMOnumber, const char *Callsign, const char *Name, uint8_t VesselType, double Length,
-                        double Beam, double PosRefStbd, double PosRefBow, uint16_t ETAdate, double ETAtime,
-                        double Draught, char const *Destination, tN2kAISVersion AISversion, tN2kGNSStype GNSStype,
-                        tN2kAISDTE DTE, tN2kAISTransceiverInformation AISinfo) {
+				  uint32_t IMOnumber, const char *Callsign, const char *Name, uint8_t VesselType, double Length,
+				  double Beam, double PosRefStbd, double PosRefBow, uint16_t ETAdate, double ETAtime,
+				  double Draught, char const *Destination, tN2kAISVersion AISversion, tN2kGNSStype GNSStype,
+				  tN2kAISDTE DTE, tN2kAISTransceiverInformation AISinfo=N2kaischannel_A_VDL_reception, uint8_t SID=0xff) {
   SetN2kPGN129794(N2kMsg, MessageID, Repeat, UserID, IMOnumber, Callsign, Name, VesselType, Length,
-                  Beam, PosRefStbd, PosRefBow, ETAdate, ETAtime, Draught, Destination, AISversion, GNSStype, DTE, AISinfo);
+                  Beam, PosRefStbd, PosRefBow, ETAdate, ETAtime, Draught, Destination, AISversion, GNSStype, DTE, AISinfo, SID);
 }
 
 /************************************************************************//**
@@ -4392,42 +4588,66 @@ inline void SetN2kAISClassAStatic(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRep
  *                        - 1 = not available = default
  * \param AISinfo         AIS Transceiver Information,
  *                        see \ref tN2kAISTransceiverInformation
- * 
+ * \param SID             Sequence ID used to bind two PGNs from the same source together
+ *
  * \return true     Parsing of PGN Message successful
  * \return false    Parsing of PGN Message aborted
  * 
  */
 bool ParseN2kPGN129794(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
-                        uint32_t &IMOnumber, char *Callsign, size_t CallsignBufSize, char *Name, size_t NameBufSize, uint8_t &VesselType, double &Length,
-                        double &Beam, double &PosRefStbd, double &PosRefBow, uint16_t &ETAdate, double &ETAtime,
-                        double &Draught, char *Destination, size_t DestinationBufSize, tN2kAISVersion &AISversion, tN2kGNSStype &GNSStype,
-                        tN2kAISDTE &DTE, tN2kAISTransceiverInformation &AISinfo);
+		       uint32_t &IMOnumber, char *Callsign, size_t CallsignBufSize, char *Name, size_t NameBufSize, uint8_t &VesselType, double &Length,
+		       double &Beam, double &PosRefStbd, double &PosRefBow, uint16_t &ETAdate, double &ETAtime,
+		       double &Draught, char *Destination, size_t DestinationBufSize, tN2kAISVersion &AISversion, tN2kGNSStype &GNSStype,
+		       tN2kAISDTE &DTE, tN2kAISTransceiverInformation &AISinfo, uint8_t &SID);
 
 /************************************************************************//**
- * \brief Parsing the content of a "AIS static data class A" 
+ * \brief Parsing the content of a "AIS static data class A"
  *        message - PGN 129794
  * \ingroup group_msgParsers
- * 
+ *
  * Alias of PGN 129794. This alias was introduced to improve the readability
- * of the source code. See parameter details on \ref ParseN2kPGN129794 
+ * of the source code. See parameter details on \ref ParseN2kPGN129794
  */
 inline bool ParseN2kAISClassAStatic(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
-                        uint32_t & IMOnumber, char *Callsign, size_t CallsignBufSize, char *Name, size_t NameBufSize, uint8_t &VesselType, double &Length,
-                        double &Beam, double &PosRefStbd, double &PosRefBow, uint16_t &ETAdate, double &ETAtime,
-                        double &Draught, char *Destination, size_t DestinationBufSize, tN2kAISVersion &AISversion, tN2kGNSStype &GNSStype,
-                        tN2kAISDTE &DTE, tN2kAISTransceiverInformation &AISinfo) {
+				    uint32_t & IMOnumber, char *Callsign, size_t CallsignBufSize, char *Name, size_t NameBufSize, uint8_t &VesselType, double &Length,
+				    double &Beam, double &PosRefStbd, double &PosRefBow, uint16_t &ETAdate, double &ETAtime,
+				    double &Draught, char *Destination, size_t DestinationBufSize, tN2kAISVersion &AISversion, tN2kGNSStype &GNSStype,
+				    tN2kAISDTE &DTE, tN2kAISTransceiverInformation &AISinfo, uint8_t &SID) {
+  return ParseN2kPGN129794(N2kMsg, MessageID, Repeat, UserID, IMOnumber, Callsign, CallsignBufSize, Name, NameBufSize, VesselType, Length,
+			   Beam, PosRefStbd, PosRefBow, ETAdate, ETAtime, Draught, Destination, DestinationBufSize,AISversion,
+			   GNSStype, DTE, AISinfo, SID);
+}
+
+/************************************************************************//**
+ * \brief Parsing the content of a "AIS static data class A"
+ *        message - PGN 129794
+ * \ingroup group_msgParsers
+ *
+ * \note Previous inline version for backwards compatibility, using temporary
+ * value to parse unused parameter
+ *
+ * Alias of PGN 129794. This alias was introduced to improve the readability
+ * of the source code. See parameter details on \ref ParseN2kPGN129794
+ */
+inline bool ParseN2kAISClassAStatic(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
+				    uint32_t & IMOnumber, char *Callsign, size_t CallsignBufSize, char *Name, size_t NameBufSize, uint8_t &VesselType, double &Length,
+				    double &Beam, double &PosRefStbd, double &PosRefBow, uint16_t &ETAdate, double &ETAtime,
+				    double &Draught, char *Destination, size_t DestinationBufSize, tN2kAISVersion &AISversion, tN2kGNSStype &GNSStype,
+				    tN2kAISDTE &DTE) {
+  tN2kAISTransceiverInformation AISinfo;
+  uint8_t SID;
   return ParseN2kPGN129794(N2kMsg, MessageID, Repeat, UserID, IMOnumber, Callsign, CallsignBufSize, Name, NameBufSize, VesselType, Length,
                           Beam, PosRefStbd, PosRefBow, ETAdate, ETAtime, Draught, Destination, DestinationBufSize,AISversion,
-                          GNSStype, DTE, AISinfo);
+			   GNSStype, DTE, AISinfo, SID);
 }
 
 /************************************************************************//**
  * \brief Setting up PGN 129809 Message "AIS static data class B part A"
  * \ingroup group_msgSetUp
- * 
+ *
  * This parameter group is used by Class B "CS" shipborne mobile equipment
  * each time Part A of ITU-R M.1372 Message 24 is received.
- * 
+ *
  * \sa [ITU-R M.1371](https://www.itu.int/rec/R-REC-M.1371)
  * \sa SetN2kPGN129810 and ParseN2kPGN129810
  * 
@@ -4444,9 +4664,13 @@ inline bool ParseN2kAISClassAStatic(const tN2kMsg &N2kMsg, uint8_t &MessageID, t
  *                        to “SAR AIRCRAFT NNNNNNN” where NNNNNNN equals
  *                        the aircraft registration number
  *                        Input string will be converted to contain only SixBit ASCII character set (see. ITU-R M.1371-1)
- * 
+ * \param AISTranseiverInformation    AIS transeiver inforation \ref tN2kAISTransceiverInformation
+ * \param SID         Sequence identifier. In most cases you can use just 0xff for SID. See \ref secRefTermSID.
+ *                    The sequence identifier field is used to tie different PGNs data together to same
+ *                    sampling or calculation time.
+ *
  */
-void SetN2kPGN129809(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, uint32_t UserID, const char *Name);
+void SetN2kPGN129809(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, uint32_t UserID, const char *Name, tN2kAISTransceiverInformation AISInfo=N2kaischannel_A_VDL_reception, uint8_t SID=0xff);
 
 /************************************************************************//**
  * \brief Setting up Message "AIS static data class B part A" - PGN 129809
@@ -4455,8 +4679,9 @@ void SetN2kPGN129809(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, u
  * Alias of PGN 129809. This alias was introduced to improve the readability
  * of the source code. See parameter details on \ref SetN2kPGN129809
   */
-inline void SetN2kAISClassBStaticPartA(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, uint32_t UserID, const char *Name) {
-  SetN2kPGN129809(N2kMsg, MessageID, Repeat, UserID, Name);
+inline void SetN2kAISClassBStaticPartA(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, uint32_t UserID, const char *Name,
+				       tN2kAISTransceiverInformation AISInfo=N2kaischannel_A_VDL_reception, uint8_t SID=0xff) {
+  SetN2kPGN129809(N2kMsg, MessageID, Repeat, UserID, Name, AISInfo, SID);
 }
 
 /************************************************************************//**
@@ -4483,23 +4708,45 @@ inline void SetN2kAISClassBStaticPartA(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kA
  *                        to “SAR AIRCRAFT NNNNNNN” where NNNNNNN equals
  *                        the aircraft registration number
  *                        Input string will be converted to contain only SixBit ASCII character set (see. ITU-R M.1371-1)
- * \param NameBufSize  size of Name buffer
+ * \param NameBufSize     size of Name buffer
+ * \param AISTranseiverInformation    AIS transeiver inforation \ref tN2kAISTransceiverInformation
+ * \param SID         Sequence identifier. In most cases you can use just 0xff for SID. See \ref secRefTermSID.
+ *                    The sequence identifier field is used to tie different PGNs data together to same
+ *                    sampling or calculation time.
  * 
  * \return true     Parsing of PGN Message successful
  * \return false    Parsing of PGN Message aborted
  */
-bool ParseN2kPGN129809(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID, char *Name, size_t NameBufSize);
+bool ParseN2kPGN129809(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID, char *Name, size_t NameBufSizem, tN2kAISTransceiverInformation &AISInfo, uint8_t &SID);
+
+/************************************************************************//**
+ * \brief Parsing the content of a "AIS static data class B part A"
+ *        message - PGN 129809
+ * \ingroup group_msgParsers
+ *
+ * Alias of PGN 129809. This alias was introduced to improve the readability
+ * of the source code. See parameter details on \ref ParseN2kPGN129809 
+ */
+inline bool ParseN2kAISClassBStaticPartA(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID, char *Name, size_t NameBufSize,
+					 tN2kAISTransceiverInformation &AISInfo, uint8_t &SID) {
+  return ParseN2kPGN129809(N2kMsg, MessageID, Repeat, UserID, Name, NameBufSize, AISInfo, SID);
+}
 
 /************************************************************************//**
  * \brief Parsing the content of a "AIS static data class B part A" 
  *        message - PGN 129809
  * \ingroup group_msgParsers
+ *
+ * \note Previous inline version for backwards compatibility, using temporary
+ * value to parse unused parameter
  * 
  * Alias of PGN 129809. This alias was introduced to improve the readability
  * of the source code. See parameter details on \ref ParseN2kPGN129809 
  */
 inline bool ParseN2kAISClassBStaticPartA(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID, char *Name, size_t NameBufSize) {
-  return ParseN2kPGN129809(N2kMsg, MessageID, Repeat, UserID, Name, NameBufSize);
+  tN2kAISTransceiverInformation AISInfo;
+  uint8_t SID;
+  return ParseN2kPGN129809(N2kMsg, MessageID, Repeat, UserID, Name, NameBufSize, AISInfo, SID);
 }
 
 /************************************************************************//**
@@ -4511,7 +4758,7 @@ inline bool ParseN2kAISClassBStaticPartA(const tN2kMsg &N2kMsg, uint8_t &Message
 
  * 
  * \sa [ITU-R M.1371](https://www.itu.int/rec/R-REC-M.1371)
- * \sa SetN2kPGN129809 and ParseN2kPGN129809
+ * \sa SetN2kPGN129810 and ParseN2kPGN129810
  * 
  * \param N2kMsg        Reference to a N2kMsg Object, 
  *                      Output: NMEA2000 message ready to be send.
@@ -4535,11 +4782,15 @@ inline bool ParseN2kAISClassBStaticPartA(const tN2kMsg &N2kMsg, uint8_t &Message
  * \param PosRefStbd      Position Reference Point from Starboard 
  * \param PosRefBow       Position Reference Point from the Bow
  * \param MothershipID    MMSI of the mothership 
+ * \param AISTranseiverInformation    AIS transeiver inforation \ref tN2kAISTransceiverInformation
+ * \param SID         Sequence identifier. In most cases you can use just 0xff for SID. See \ref secRefTermSID.
+ *                    The sequence identifier field is used to tie different PGNs data together to same
+ *                    sampling or calculation time.
  * 
  */
 void SetN2kPGN129810(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, uint32_t UserID,
-                      uint8_t VesselType, const char *Vendor, const char *Callsign, double Length, double Beam,
-                      double PosRefStbd, double PosRefBow, uint32_t MothershipID);
+		     uint8_t VesselType, const char *Vendor, const char *Callsign, double Length, double Beam,
+		     double PosRefStbd, double PosRefBow, uint32_t MothershipID, tN2kAISTransceiverInformation AISInfo=N2kaischannel_A_VDL_reception, uint8_t SID=0xff);
 
 /************************************************************************//**
  * \brief Setting up Message "AIS static data class B part B" - PGN 129810
@@ -4549,10 +4800,11 @@ void SetN2kPGN129810(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, u
  * of the source code. See parameter details on \ref SetN2kPGN129810
   */
 inline void SetN2kAISClassBStaticPartB(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kAISRepeat Repeat, uint32_t UserID,
-                      uint8_t VesselType, const char *Vendor, const char *Callsign, double Length, double Beam,
-                      double PosRefStbd, double PosRefBow, uint32_t MothershipID) {
+				       uint8_t VesselType, const char *Vendor, const char *Callsign, double Length, double Beam,
+				       double PosRefStbd, double PosRefBow, uint32_t MothershipID,
+				       tN2kAISTransceiverInformation AISInfo=N2kaischannel_A_VDL_reception, uint8_t SID=0xff) {
   SetN2kPGN129810(N2kMsg, MessageID, Repeat, UserID, VesselType, Vendor, Callsign, Length, Beam,
-                  PosRefStbd, PosRefBow, MothershipID);
+                  PosRefStbd, PosRefBow, MothershipID, AISInfo, SID);
 }
 
 /************************************************************************//**
@@ -4590,14 +4842,18 @@ inline void SetN2kAISClassBStaticPartB(tN2kMsg &N2kMsg, uint8_t MessageID, tN2kA
  * \param PosRefStbd      Position Reference Point from Starboard 
  * \param PosRefBow       Position Reference Point from the Bow
  * \param MothershipID    MMSI of the mothership 
+ * \param AISTranseiverInformation    AIS transeiver inforation, \ref tN2kAISTransceiverInformation
+ * \param SID         Sequence identifier. In most cases you can use just 0xff for SID. See \ref secRefTermSID.
+ *                    The sequence identifier field is used to tie different PGNs data together to same
+ *                    sampling or calculation time.
  * 
  * \return true     Parsing of PGN Message successful
  * \return false    Parsing of PGN Message aborted
  * 
  */
 bool ParseN2kPGN129810(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
-                      uint8_t &VesselType, const char *Vendor, size_t VendorBufSize, const char *Callsign, size_t CallsignBufSize,double &Length, double &Beam,
-                      double &PosRefStbd, double &PosRefBow, uint32_t &MothershipID);
+		       uint8_t &VesselType, char *Vendor, size_t VendorBufSize, char *Callsign, size_t CallsignBufSize,double &Length, double &Beam,
+		       double &PosRefStbd, double &PosRefBow, uint32_t &MothershipID, tN2kAISTransceiverInformation &AISInfo, uint8_t &SID);
 
 /************************************************************************//**
  * \brief Parsing the content of a "AIS static data class B part B" 
@@ -4608,10 +4864,30 @@ bool ParseN2kPGN129810(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat 
  * of the source code. See parameter details on \ref ParseN2kPGN129810 
  */
 inline bool ParseN2kAISClassBStaticPartB(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
-		      uint8_t &VesselType, char *Vendor, size_t VendorBufSize, char *Callsign, size_t CallsignBufSize, double &Length, double &Beam,
-                      double &PosRefStbd, double &PosRefBow, uint32_t &MothershipID) {
+					 uint8_t &VesselType, char *Vendor, size_t VendorBufSize, char *Callsign, size_t CallsignBufSize, double &Length, double &Beam,
+					 double &PosRefStbd, double &PosRefBow, uint32_t &MothershipID, tN2kAISTransceiverInformation &AISInfo, uint8_t &SID ) {
   return ParseN2kPGN129810(N2kMsg, MessageID, Repeat, UserID, VesselType, Vendor, VendorBufSize, Callsign, CallsignBufSize,
-                                Length, Beam, PosRefStbd, PosRefBow, MothershipID);
+			   Length, Beam, PosRefStbd, PosRefBow, MothershipID, AISInfo, SID);
+}
+
+/************************************************************************//**
+ * \brief Parsing the content of a "AIS static data class B part B"
+ *        message - PGN 129810
+ * \ingroup group_msgParsers
+ *
+ * \note Previous inline version for backwards compatibility, using temporary
+ * value to parse unused parameter
+ *
+ * Alias of PGN 129810. This alias was introduced to improve the readability
+ * of the source code. See parameter details on \ref ParseN2kPGN129810
+ */
+inline bool ParseN2kAISClassBStaticPartB(const tN2kMsg &N2kMsg, uint8_t &MessageID, tN2kAISRepeat &Repeat, uint32_t &UserID,
+					 uint8_t &VesselType, char *Vendor, size_t VendorBufSize, char *Callsign, size_t CallsignBufSize, double &Length, double &Beam,
+					 double &PosRefStbd, double &PosRefBow, uint32_t &MothershipID) {
+  tN2kAISTransceiverInformation AISInfo;
+  uint8_t SID;
+  return ParseN2kPGN129810(N2kMsg, MessageID, Repeat, UserID, VesselType, Vendor, VendorBufSize, Callsign, CallsignBufSize,
+			   Length, Beam, PosRefStbd, PosRefBow, MothershipID, AISInfo, SID);
 }
 
 /************************************************************************//**

--- a/src/N2kTypes.h
+++ b/src/N2kTypes.h
@@ -491,7 +491,6 @@ enum tN2kOnOff  {
                             N2kOnOff_Error=2,       ///< Error
                             N2kOnOff_Unavailable=3  ///< Unavailable
                           };
-
 /*************************************************************************//**
  * \enum tN2kChargeState
  * \brief Enumeration of state of the battery charger operation according to
@@ -508,9 +507,9 @@ enum tN2kChargeState  {
                             N2kCS_Constant_VI=7,      ///< Charger operation state is in constant power
                             N2kCS_Disabled=8,         ///< Charger operation state is disabled
                             N2kCS_Fault=9,            ///< Charger operation state is in fault
+			    N2kCS_Error=14,           ///< Charger operation state is in error
                             N2kCS_Unavailable=15      ///< Charger operation state unavailable
                           };
-
 /*************************************************************************//**
  * \enum tN2kChargerMode
  * \brief Enumeration of charger modes according to PGN 127507
@@ -572,6 +571,96 @@ enum tN2kMOBPositionSource {
 enum tN2kMOBEmitterBatteryStatus {
                            Good=0,    ///< Battery status of the MOB emitter is good
                            Low=1,     ///< Battery status of the MOB emitter is low
+                          };
+/*************************************************************************//**
+ * \enum tN2kConvMode
+ * \brief Converter (Inverter/Charger) mode
+ */
+enum tN2kConvMode {  // https://github.com/canboat/canboat/pull/197/commits/a4b04eed02fce1e3d5f484920a9355d07757d007
+                           N2kCICS_Off=0,
+                           N2kCICS_LP_Mode=1,                              // Low Power mode
+                           N2kCICS_Fault=2,
+                           N2kCICS_Bulk=3,
+                           N2kCICS_Absorption=4,
+                           N2kCICS_Float=5,
+                           N2kCICS_Storage=6,
+                           N2kCICS_Equalise=7,
+                           N2kCICS_Passthru=8,
+                           N2kCICS_Inverting=9,
+                           N2kCICS_Assisting=10,
+                           N2kCICS_PSU_Mode=11,
+                           N2kCICS_Hub1=0xFC,                              // In slave/DDDC mode
+                           N2kCICS_NotAvailable=0XFF
+                        };
+
+/*************************************************************************//**
+ * \enum tN2kRippleState
+ * \brief Converter (Inverter/Charger) ripple state
+ */
+enum tN2kRippleState {
+                           N2kRP_OK=0,
+                           N2kRP_Warning=1,
+                           N2kRP_High=2,                                    // Ripple too high
+                           N2kRP_NotAvailable=3
+                       };
+
+/*************************************************************************//**
+ * \enum tN2kDCVolgateState
+ * \brief Converter (Inverter/Charger) DC voltage state
+ */
+enum tN2kDCVolgateState {
+                           N2kDCVS_OK=0,
+                           N2kDCVS_Warning=1,
+                           N2kDCVS_Low=3,                                       // DC Voltage too low
+                           N2kDCVS_NotAvailable=3
+                        };
+
+/*************************************************************************//**
+ * \enum tN2kDCVolgateState
+ * \brief Converter (Inverter/Charger) overload state
+ */
+enum tN2kOverloadState {
+                           N2kOS_OK=0,
+                           N2kOS_Warning=1,
+                           N2kOS_Overload=2,
+                           N2kOS_NotAvailable=3
+                         };
+
+/*************************************************************************//**
+ * \enum tN2kTemperatureState
+ * \brief Converter (Inverter/Charger) temperature state
+ */
+enum tN2kTemperatureState {
+                           N2kTS_OK=0,
+                           N2kTS_Warning=1,
+                           N2kTS_High=3,                                         // Over Temperature
+                           N2kTS_NotAvailable=3
+                         };
+
+/*************************************************************************//**
+ * \enum tN2kChargingAlgorithm
+ * \brief Enumeration of Charging Algorithms
+ */
+enum tN2kChargingAlgorithm {
+                            N2kCA_Trickle = 0,
+                            N2kCA_CVCC = 1,    /// Constant Voltage Constant Current)
+			    N2kCA_2Stage = 2,  /// 2nd Stage (no Float)
+			    N2kCA_3State = 3,  /// 3rd stage
+			    N2kCA_Error = 14,
+                            N2kCA_NotAvailable = 15
+                          };
+
+
+/*************************************************************************//**
+ * \enum tBattTempNoSensor
+ * \brief Battery temperature with no temperature sensor
+ */
+enum tBattTempNoSensor {
+                            N2kBT_cold = 0,
+                            N2kBT_warm = 1,
+                            N2kBT_hot  = 2,
+                            N2kBT_Error = 14,
+                            N2kBT_NotAvailable = 15
                           };
 
 //*****************************************************************************

--- a/src/NMEA2000.cpp
+++ b/src/NMEA2000.cpp
@@ -250,12 +250,14 @@ bool IsFastPacketSystemMessage(unsigned long PGN) {
  *              - 127245L: Rudder, pri=2, period=100
  *              - 127250L: Vessel Heading, pri=2, period=100
  *              - 127251L: Rate of Turn, pri=2, period=100
+ *              - 127252L: Heave, pri=3, period=100
  *              - 127257L: Attitude, pri=3, period=1000
  *              - 127488L: Engine parameters rapid, rapid Update, pri=2, period=100
  *              - 127493L: Transmission parameters: dynamic, pri=2, period=100
  *              - 127501L: Binary status report, pri=3, period=NA
  *              - 127505L: Fluid level, pri=6, period=2500
  *              - 127508L: Battery Status, pri=6, period=1500
+ *              - 127750L: Charger status new, pri=6, period=1500
  *              - 128259L: Boat speed, pri=2, period=1000
  *              - 128267L: Water depth, pri=3, period=1000
  *              - 129025L: Lat/lon rapid, pri=2, period=100
@@ -280,12 +282,14 @@ bool IsDefaultSingleFrameMessage(unsigned long PGN) {
                                       case 127245L: // Rudder, pri=2, period=100
                                       case 127250L: // Vessel Heading, pri=2, period=100
                                       case 127251L: // Rate of Turn, pri=2, period=100
+				      case 127252L: // Heave, pri=3, period=100
                                       case 127257L: // Attitude, pri=3, period=1000
                                       case 127488L: // Engine parameters rapid, rapid Update, pri=2, period=100
                                       case 127493L: // Transmission parameters: dynamic, pri=2, period=100
                                       case 127501L: // Binary status report, pri=3, period=NA
                                       case 127505L: // Fluid level, pri=6, period=2500
                                       case 127508L: // Battery Status, pri=6, period=1500
+				      case 127750L: // Charger status new, pri=6, period=1500
                                       case 128259L: // Boat speed, pri=2, period=1000
                                       case 128267L: // Water depth, pri=3, period=1000
                                       case 129025L: // Lat/lon rapid, pri=2, period=100


### PR DESCRIPTION

Added PGN 127510
Added PGN 127750
Modified AIS PGN PGN 129038, 129039, 129794, 129809, and 129810 to include AIS Transceiver Info and SID (where applicable)

Argument list for AIS PGNs has changed but added stubs to keep backward compatibility with previous versions.