### PR TITLE
Fix for invalid length GetVarStr

### DIFF
--- a/src/N2kMsg.cpp
+++ b/src/N2kMsg.cpp
@@ -417,7 +417,7 @@ bool tN2kMsg::GetStr(size_t StrBufSize, char *StrBuf, size_t Length, unsigned ch
 bool tN2kMsg::GetVarStr(size_t &StrBufSize, char *StrBuf, int &Index) const {
   size_t Len=GetByte(Index);
   uint8_t Type=GetByte(Index);
-  if ( Len == 0) { StrBufSize=0; return false; } // invalid length
+  if ( Len<2) { StrBufSize=0; return false; } // invalid length
   Len-=2;
   if ( Type!=0x01 ) { StrBufSize=0; return false; }
   if ( StrBuf!=0 ) {

--- a/src/N2kMsg.cpp
+++ b/src/N2kMsg.cpp
@@ -415,8 +415,10 @@ bool tN2kMsg::GetStr(size_t StrBufSize, char *StrBuf, size_t Length, unsigned ch
 
 //*****************************************************************************
 bool tN2kMsg::GetVarStr(size_t &StrBufSize, char *StrBuf, int &Index) const {
-  size_t Len=GetByte(Index)-2;
+  size_t Len=GetByte(Index);
   uint8_t Type=GetByte(Index);
+  if ( Len == 0) { StrBufSize=0; return false; } // invalid length
+  Len-=2;
   if ( Type!=0x01 ) { StrBufSize=0; return false; }
   if ( StrBuf!=0 ) {
     GetStr(StrBufSize,StrBuf,Len,0xff,Index);


### PR DESCRIPTION
```
6   2 255 126998 Configuration Information:  18 01 44 43 20 44 69 73 74 72 69 62 75 74 69 6F 0E 20 4D 6F 64 75 6C 65 02 01 00 01 54 72 69 67 65 6E 74 69 63 20 41 42
                                                                                                                           ^^
6   2 255 126998 Configuration Information:   .  .  D  C  .  D  i  s  t  r  i  b  u  t  i  o  .  .  M  o  d  u  l  e  .  .  .  .  T  r  i  g  e  n  t  i  c  .  A  B
[analyzer] field 'Manufacturer Information': Invalid string length 0 in STRING_LAU field
```

The message above contains an error at '^^' (length location). 
