### PR TITLE
Use C++ style callback interfaces as a variant of existing C function callbacks

### DIFF
--- a/src/ActisenseReader.cpp
+++ b/src/ActisenseReader.cpp
@@ -158,7 +158,7 @@ bool tActisenseReader::GetMessageFromStream(tN2kMsg &N2kMsg, bool ReadOut) {
               ReadStream->read(); // Read ch out
               ClearBuffer();
               StartOfTextReceived=true;
-            }
+            } else if ( ReadOut ) ReadStream->read(); // Read character to ensure the same character is not handled again in the loop
             break;
           default:
             EscapeReceived=(NewByte==Escape);

--- a/src/ActisenseReader.cpp
+++ b/src/ActisenseReader.cpp
@@ -185,6 +185,7 @@ void tActisenseReader::ParseMessages() {
 
     while (GetMessageFromStream(N2kMsg)) {
       if (MsgHandler!=0) MsgHandler(N2kMsg);
+      if (CallbackHandlerInterface!=0) CallbackHandlerInterface->OnMessage(N2kMsg);
     }
 }
 

--- a/src/ActisenseReader.h
+++ b/src/ActisenseReader.h
@@ -41,6 +41,25 @@
 #include "N2kStream.h"
 
 /************************************************************************//**
+ * \class tActisenseReaderCallbackInterface
+ * \brief Interface for handling 'OnMessage' callbacks from tActisenseReader
+ * \ingroup group_helperClass
+ *
+ * This is an interface that might be implemented and passed as an instance
+ * using method 'SetCallbackHandlerInterface'. It's an alternative to use
+ * instead of 'SetMsgHandler', when there is a need to use C++ instances
+ * instead of C-like function pointers.
+ *
+ */
+class tActisenseReaderCallbackInterface
+{
+public:
+  virtual ~tActisenseReaderCallbackInterface() { }
+
+  virtual void OnMessage(const tN2kMsg &N2kMsg) = 0;
+};
+
+/************************************************************************//**
  * \class tActisenseReader
  * \brief Class for reading Actisense format messages
  * \ingroup group_helperClass
@@ -79,6 +98,8 @@ protected:
     N2kStream* ReadStream;
     // Handler callback
     void (*MsgHandler)(const tN2kMsg &N2kMsg);
+    /** \brief C++ variant of handling callbacks as an alternative to C-like 'MsgHandler' */
+    tActisenseReaderCallbackInterface* CallbackHandlerInterface;
 
 protected:
     /********************************************************************//**
@@ -121,6 +142,17 @@ public:
      */
      
     void SetReadStream(N2kStream* _stream) { ReadStream=_stream; }
+
+    /********************************************************************//**
+     * \brief Set callback handler interface instance
+     *
+     * Set a pointer to an instance of a callback handler to be executed when
+     * new messages arrive from Actisense protocol.
+     *
+     * \param _callbackHandlerInterface   The callback handler instance
+     */
+
+    void SetCallbackHandlerInterface(tActisenseReaderCallbackInterface* _callbackHandlerInterface) { CallbackHandlerInterface=_callbackHandlerInterface; }
 
     /********************************************************************//**
      * \brief Set the default source address for the messages

--- a/src/NMEA2000.h
+++ b/src/NMEA2000.h
@@ -108,6 +108,27 @@
 #define N2kNullCanBusAddress 254
 
 /************************************************************************//**
+ * \class tNMEA2000CallbackInterface
+ * \brief Interface for handling various NMEA2000 callbacks using C++ objects
+ * \ingroup group_helperClass
+ *
+ * This is an interface that might be implemented and passed as an instance
+ * using method 'SetCallbackHandlerInterface'. It's an alternative to use
+ * instead of 'OnOpen', 'MsgHandler', and 'ISORqstHandler', when there is a
+ * need to use C++ instances instead of C-like function pointers.
+ *
+ */
+class tNMEA2000CallbackInterface
+{
+public:
+  virtual ~tNMEA2000CallbackInterface() { }
+
+  virtual void OnOpen() = 0;
+  virtual void OnMessage(const tN2kMsg &N2kMsg) = 0;
+  virtual bool OnIsoRequest(unsigned long RequestedPGN, unsigned char Requester, int DeviceIndex) = 0;
+};
+
+/************************************************************************//**
  * \class tNMEA2000
  * \brief tNMEA2000 device class definition.
  * \ingroup group_core
@@ -1077,6 +1098,9 @@ protected:
     void (*MsgHandler)(const tN2kMsg &N2kMsg);  
     /** \brief Handler callbacks for 'ISORequest' messages */
     bool (*ISORqstHandler)(unsigned long RequestedPGN, unsigned char Requester, int DeviceIndex);
+
+    /** \brief C++ variant of handling callbacks as an alternative to C-like function pointers */
+    tNMEA2000CallbackInterface *CallbackHandlerInterface;
 
 #if !defined(N2K_NO_GROUP_FUNCTION_SUPPORT)
     /** \brief Pointer to Buffer for GRoup Function Handlers*/
@@ -2791,6 +2815,18 @@ public:
      * \param ISORequestHandler Message handler
      */
     void SetISORqstHandler(bool(*ISORequestHandler)(unsigned long RequestedPGN, unsigned char Requester, int DeviceIndex));
+
+    /********************************************************************//**
+     * \brief Set callback handler interface instance
+     *
+     * Set a pointer to an instance of a callback handler to be executed as
+     * an alternative to using C-like function pointer callbacks for 'OnOpen',
+     * 'MsgHandler', and 'ISORqstHandler'. The callback handler must implement
+     * all virtual methods of the interface.
+     *
+     * \param _CallbackHandlerInterface   The callback handler instance
+     */
+    void SetCallbackHandlerInterface(tNMEA2000CallbackInterface *_CallbackHandlerInterface);
 
 #if !defined(N2K_NO_GROUP_FUNCTION_SUPPORT)
     


### PR DESCRIPTION
Without breaking any compatibility, these changes extends tActisenseReader and tNMEA2000 classes to allow C++ interface style callbacks. This makes it easier to integrate with other C++ classes, instead of using simple C function pointers. This also fixes a bug in tActisenseReader that could end up in an endless loop.