### PR TITLE
PGN130316 Temperature 3byte unsigned  double

### DIFF
--- a/src/N2kMessages.cpp
+++ b/src/N2kMessages.cpp
@@ -2053,7 +2053,7 @@ void SetN2kPGN130316(tN2kMsg &N2kMsg, unsigned char SID, unsigned char TempInsta
     N2kMsg.AddByte(SID);
     N2kMsg.AddByte((unsigned char)TempInstance);
     N2kMsg.AddByte((unsigned char)TempSource);
-    N2kMsg.Add3ByteDouble(ActualTemperature,0.001);
+    N2kMsg.Add3ByteUDouble(ActualTemperature,0.001);
     N2kMsg.Add2ByteUDouble(SetTemperature,0.1);
 }
 
@@ -2064,7 +2064,7 @@ bool ParseN2kPGN130316(const tN2kMsg &N2kMsg, unsigned char &SID, unsigned char 
   SID=N2kMsg.GetByte(Index);
   TempInstance=N2kMsg.GetByte(Index);
   TempSource=(tN2kTempSource)(N2kMsg.GetByte(Index));
-  ActualTemperature=N2kMsg.Get3ByteDouble(0.001,Index);
+  ActualTemperature=N2kMsg.Get3ByteUDouble(0.001,Index);
   SetTemperature=N2kMsg.Get2ByteUDouble(0.1,Index);
 
   return true;

--- a/src/N2kMsg.cpp
+++ b/src/N2kMsg.cpp
@@ -749,7 +749,7 @@ double GetBuf3ByteDouble(double precision, int &index, const unsigned char *buf,
 }
 
 //*****************************************************************************
-double GetBuf3ByteUouble(double precision, int &index, const unsigned char *buf, double def) {
+double GetBuf3ByteUDouble(double precision, int &index, const unsigned char *buf, double def) {
   int32_t vl = GetBuf<int32_t>(3, index, buf);
   if (vl==0x00ffffff) return def;
 

--- a/src/N2kMsg.cpp
+++ b/src/N2kMsg.cpp
@@ -598,7 +598,6 @@ void SetBufFloat(float v, int &index, unsigned char *buf) {
 #define N2kUInt32OR 0xfffffffe
 
 #define N2kInt32Min -2147483648L
-#define N2kInt24OR  8388606L
 #define N2kInt24Min -8388608L
 #define N2kInt16Min -32768
 #define N2kInt8Min  -128

--- a/src/N2kMsg.cpp
+++ b/src/N2kMsg.cpp
@@ -144,6 +144,15 @@ void tN2kMsg::Add3ByteDouble(double v, double precision, double UndefVal) {
 }
 
 //*****************************************************************************
+void tN2kMsg::Add3ByteUDouble(double v, double precision, double UndefVal) {
+  if (v!=UndefVal) {
+    SetBuf3ByteUDouble(v,precision,DataLen,Data);
+  } else {
+    SetBuf3ByteUInt(0xffffff,DataLen,Data);
+  }
+}
+
+//*****************************************************************************
 void tN2kMsg::Add2ByteDouble(double v, double precision, double UndefVal) {
   if (v!=UndefVal) {
     SetBuf2ByteDouble(v,precision,DataLen,Data);
@@ -325,6 +334,13 @@ double tN2kMsg::Get2ByteUDouble(double precision, int &Index, double def) const 
 double tN2kMsg::Get3ByteDouble(double precision, int &Index, double def) const {
   if (Index+3<=DataLen) {
     return GetBuf3ByteDouble(precision,Index,Data,def);
+  } else return def;
+}
+
+//*****************************************************************************
+double tN2kMsg::Get3ByteUDouble(double precision, int &Index, double def) const {
+  if (Index+3<=DataLen) {
+    return GetBuf3ByteUDouble(precision,Index,Data,def);
   } else return def;
 }
 
@@ -576,6 +592,8 @@ void SetBufFloat(float v, int &index, unsigned char *buf) {
 #define N2kUInt8OR 0xfe
 #define N2kInt16OR 0x7ffe
 #define N2kUInt16OR 0xfffe
+#define N2kInt24OR 0x7ffffe
+#define N2kUInt24OR 0xfffffe
 #define N2kInt32OR 0x7ffffffe
 #define N2kUInt32OR 0xfffffffe
 
@@ -621,6 +639,13 @@ void SetBuf4ByteUDouble(double v, double precision, int &index, unsigned char *b
 void SetBuf3ByteDouble(double v, double precision, int &index, unsigned char *buf) {
   double vd=round((v/precision));
   int32_t vi = (vd>=N2kInt24Min && vd<N2kInt24OR)?(int32_t)vd:N2kInt24OR;
+  SetBuf<int32_t>(vi, 3, index, buf);
+}
+
+//*****************************************************************************
+void SetBuf3ByteUDouble(double v, double precision, int &index, unsigned char *buf) {
+  double vd=round((v/precision));
+  int32_t vi = (vd>=0 && vd<N2kUInt24OR)?(int32_t)vd:N2kUInt24OR;
   SetBuf<int32_t>(vi, 3, index, buf);
 }
 
@@ -725,6 +750,14 @@ double GetBuf3ByteDouble(double precision, int &index, const unsigned char *buf,
 }
 
 //*****************************************************************************
+double GetBuf3ByteUouble(double precision, int &index, const unsigned char *buf, double def) {
+  int32_t vl = GetBuf<int32_t>(3, index, buf);
+  if (vl==0x00ffffff) return def;
+
+  return vl * precision;
+}
+
+//*****************************************************************************
 double GetBuf4ByteDouble(double precision, int &index, const unsigned char *buf, double def) {
   int32_t vl = GetBuf<int32_t>(4, index, buf);
   if (vl==0x7fffffff) return def;
@@ -782,6 +815,12 @@ void SetBuf2ByteUInt(uint16_t v, int &index, unsigned char *buf) {
 void SetBuf3ByteInt(int32_t v, int &index, unsigned char *buf) {
   SetBuf(v, 3, index, buf);
 }
+
+//*****************************************************************************
+void SetBuf3ByteUInt(int32_t v, int &index, unsigned char *buf) {
+  SetBuf(v, 3, index, buf);
+}
+
 
 //*****************************************************************************
 void SetBuf4ByteUInt(uint32_t v, int &index, unsigned char *buf) {

--- a/src/N2kMsg.h
+++ b/src/N2kMsg.h
@@ -257,6 +257,24 @@ void SetBuf4ByteUDouble(double v, double precision, int &index, unsigned char *b
 void SetBuf3ByteDouble(double v, double precision, int &index, unsigned char *buf);
 
 /**************************************************************************//**
+ * \brief Writes a double unsigned value into a byte array buffer using 3 bytes
+ *
+ * To write a double value into a certain position of an byte array buffer
+ * the function memcpy is used. Out of range will be handled. So if given
+ * value can not be converted to fixed integer, "out of range" constant
+ * will be set. 
+ * 
+ * There are different functions depending on how many byte should be used
+ * in the buffer. The fixed point integer mechanism is used.
+ * 
+ * \param v {double} Value to be stored in the Buffer
+ * \param precision the value is rounded to the given precision (e.g. 0.01)
+ * \param index     Position where the value should be placed inside the buffer
+ * \param buf       Pointer to the byte array buffer 
+ */
+void SetBuf3ByteUDouble(double v, double precision, int &index, unsigned char *buf);
+
+/**************************************************************************//**
  * \brief Writes a double signed value into a byte array buffer using 2 bytes
  *
  * To write a double value into a certain position of an byte array buffer
@@ -371,6 +389,21 @@ void SetBuf2ByteUInt(uint16_t v, int &index, unsigned char *buf);
  * \param buf       Pointer to the byte array buffer 
  */
 void SetBuf3ByteInt(int32_t v, int &index, unsigned char *buf);
+
+/**************************************************************************//**
+ * \brief Writes an unsigned integer value into a byte array buffer using 
+ * 3 bytes
+ * To write a integer value into a certain position of an byte array buffer
+ * the function memcpy is used. 
+ * 
+ * There are different functions depending on how many byte should be used
+ * in the buffer
+ * 
+ * \param v         Value to be stored in the Buffer
+ * \param index     Position where the value should be placed inside the buffer
+ * \param buf       Pointer to the byte array buffer 
+ */
+void SetBuf3ByteUInt(int32_t v, int &index, unsigned char *buf);
 
 /**************************************************************************//**
  * \brief Writes an unsigned integer value into a byte array buffer u

--- a/src/N2kMsg.h
+++ b/src/N2kMsg.h
@@ -593,6 +593,23 @@ double GetBuf2ByteUDouble(double precision, int &index, const unsigned char *buf
 double GetBuf3ByteDouble(double precision, int &index, const unsigned char *buf, double def=0);
 
 /**************************************************************************//**
+ * \brief Extracts 3 bytes out of the given buffer
+ * and converts it to a double value.
+ * 
+ * The fixed point integer mechanism is used.
+ * 
+ * \param precision the value is rounded to the given precision (e.g. 0.01)
+ * \param index       position inside the byte array \ref tN2kMsg::Data, getting
+ *                    incremented according to the number of bytes
+ *                    extracted
+ * \param buf   Pointer to the byte array buffer 
+ * \param def   default value that will be returned if the byte array
+ *              equal to "not available"
+ * \return      double value
+ */
+double GetBuf3ByteUDouble(double precision, int &index, const unsigned char *buf, double def=0);
+
+/**************************************************************************//**
  * \brief Extracts 4 bytes out of the given buffer
  * and converts it to a double value.
  * 

--- a/src/N2kMsg.h
+++ b/src/N2kMsg.h
@@ -840,6 +840,19 @@ public:
   void Add3ByteDouble(double v, double precision, double UndefVal=N2kDoubleNA);
 
   /************************************************************************//**
+   * \brief Add double value to the buffer using 3 bytes
+   * 
+   * The fixed point integer mechanism is used.
+   * The value will be added to the end (indicated by \ref DataLen) of
+   * the byte array \ref Data.
+   * 
+   * \param precision the value is rounded to the given precision (e.g. 0.01)
+   * \param v         value to add
+   * \param UndefVal  "not available" value
+   */
+  void Add3ByteUDouble(double v, double precision, double UndefVal=N2kDoubleNA);
+
+  /************************************************************************//**
    * \brief Add double value to the buffer using 2 bytes
    * 
    * The fixed point integer mechanism is used.
@@ -1110,6 +1123,19 @@ public:
   * \return        double value
   */
   double Get3ByteDouble(double precision, int &Index, double def=N2kDoubleNA) const;
+
+  /************************************************************************//**
+  * \brief Get a double from 3 bytes out of \ref Data
+  * The fixed point integer mechanism is used.
+  * 
+  * \param precision the value is rounded to the given precision (e.g. 0.01)
+  * \param Index       position inside the byte array \ref Data, getting
+  *                    incremented according to the number of bytes
+  *                    extracted
+  * \param def     default value when data is unavailable
+  * \return        double value
+  */
+  double Get3ByteUDouble(double precision, int &Index, double def=N2kDoubleNA) const;
 
   /************************************************************************//**
   * \brief Get a double from 4 bytes out of \ref Data


### PR DESCRIPTION
Fixed the implementation of the PGN 130316 Temperature from signed 3 byte double to unsigned 3 byte double