### PR TITLE
Minor debug logging improvements

### DIFF
--- a/src/N2kStream.cpp
+++ b/src/N2kStream.cpp
@@ -72,12 +72,16 @@ size_t N2kStream::print(int val, uint8_t radix) {
    return print(ptr);
 }
 
+size_t N2kStream::println(void) {
+   return print("\r\n");
+}
+
 size_t N2kStream::println(const char *str) {
-   return print(str) + print("\r\n");
+   return print(str) + println();
 }
 
 size_t N2kStream::println(int val, uint8_t radix) {
-   return print(val, radix) + print("\r\n");
+   return print(val, radix) + println();
 }
 
 #endif

--- a/src/N2kStream.h
+++ b/src/N2kStream.h
@@ -106,6 +106,14 @@ class N2kStream {
    size_t print(int val, uint8_t radix = 10);
 
    /***********************************************************************//**
+    * \brief Print newline to stream.
+    * 
+    * \param str  String data for the stream
+    * \return size_t 
+    */
+   size_t println(void);
+
+   /***********************************************************************//**
     * \brief Print string and newline to stream.
     * 
     * \param str  String data for the stream


### PR DESCRIPTION
Minor changes to debug logging for finer grained control.
Also fixed logging output for non Arduino target (ESP-IDF).
By using `#define DebugStream (*ForwardStream)` and adding missing function `size_t N2kStream::println(void)`