### PR TITLE
Add an intentional assert fail if the destructor is called.

### DIFF
--- a/src/NMEA2000.cpp
+++ b/src/NMEA2000.cpp
@@ -28,6 +28,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #endif
 #include <string.h>
 #include <stdlib.h>
+#include <assert.h>
 
 // #define DebugStream Serial   // outputs debug messages to the serial console (only for Arduino)
 #define DebugStream (*ForwardStream) // outputs debug messages to same destination as ForwardStream
@@ -738,6 +739,14 @@ tNMEA2000::tNMEA2000() {
                                      DefInstallationDescription2);
   Devices=0;
   DeviceCount=1;
+}
+
+//*****************************************************************************
+tNMEA2000::~tNMEA2000()
+{
+    // Note this class was not designed to be deleted. Delete the destructor to raise a compiler error if someone tries to delete this class.
+    // TODO: add a proper destructor
+    assert(false && "tNMEA2000 destructor called");
 }
 
 //*****************************************************************************

--- a/src/NMEA2000.h
+++ b/src/NMEA2000.h
@@ -1754,6 +1754,12 @@ public:
      */
     tNMEA2000();
 
+    /*********************************************************************//**
+    * \brief Destroy the tNMEA2000 object
+    * 
+    */ 
+    virtual ~tNMEA2000();
+
     /**********************************************************************//**
      * \brief Finds a device on \ref Devices by its source address
      *


### PR DESCRIPTION
It was not clear to me that the class destructor was not implemented and I wasted a lot of my time with memory related issues on my project. 
I propose to add an intentional assert failure if the destructor is called on the NMEA2000 object because it is not implemented and would lead to memory leaks. 

This should hopefully be a temporary solution until a proper destructor can be implemented. (We tried to implement a proper destructor, but ran into issues with freeing pGroupFunctionHandlers. The AddGroupFunctionHandler() object ownership is ambiguous and it might require a breaking change to the API to fix it). For now I think the best option is to fail-fast instead of causing difficult to diagnose issues.  

See discussion in https://github.com/ttlappalainen/NMEA2000/issues/213

It appears to add about 220 bytes to the binary according to the Memory usage change bot. See the memory report on my fork: https://github.com/phatpaul/NMEA2000/pull/2