### PR TITLE
Improved Restart() function

### DIFF
--- a/src/NMEA2000.cpp
+++ b/src/NMEA2000.cpp
@@ -1282,6 +1282,7 @@ bool tNMEA2000::Open() {
   // Initialization so we start sending delayed.
   if ( OpenState==os_WaitOpen && OpenScheduler.IsTime() ) {
     OpenState=os_Open;
+    OpenScheduler.Disable();
     StartAddressClaim();
     tN2kSyncScheduler::SetSyncOffset();
     #if !defined(N2K_NO_HEARTBEAT_SUPPORT)
@@ -1301,8 +1302,24 @@ bool tNMEA2000::Open() {
 }
 
 //*****************************************************************************
-void tNMEA2000::Restart() {
-  StartAddressClaim();
+void tNMEA2000::Restart()
+{
+  if (OpenState > os_None)
+  {
+    CANSendFrameBufferWrite = 0;
+    CANSendFrameBufferRead = 0;
+    for (int i = 0; i < MaxN2kCANMsgs; i++)
+    {
+      N2kCANMsgBuf[i].FreeMessage();
+    }
+    // Assume that driver called Restart(), so it is ready to go.
+    // No need to call InitCANxx(), CANOpen(), etc.
+    if (OpenState > os_OpenCAN)
+    {
+      OpenState = os_WaitOpen;
+      OpenScheduler.FromNow(200);
+    }
+  }
 }
 
 /************************************************************************//**

--- a/src/NMEA2000.h
+++ b/src/NMEA2000.h
@@ -2634,13 +2634,9 @@ public:
     inline bool IsOpen() const { return OpenState==os_Open; }
 
     /*********************************************************************//**
-     * \brief Restart the device
+     * \brief Restart the library after CAN driver detects bus is ready.
      * 
-     * This is preliminary function for e.g. battery powered or devices, 
-     * which may go to sleep or of the bus in any way. Function is under 
-     * development.
-     * 
-     * \note At the moment this functions just restarts the IsoAddressClaim
+     * This should only be called by the driver and assumes the CAN driver is in ready state.
      */
     void Restart();
 


### PR DESCRIPTION
Fixes Restart() function so it triggers a full reset of the state. Now Restart() can be called (i.e. by the CAN driver after it detects bus error and performs bus recovery and bus restart) and the stack will properly reinitialize and restart the address claim.

This should not cause any harm to applications that don't make use of the Restart() function.

## Usage example: 
This is how my [phatpaul/NMEA2000_esp32_autorestart](https://github.com/phatpaul/NMEA2000_esp32_autorestart) driver class monitors the lower level driver and can restart the stack when necessary. With this I can unplug/replug the CAN bus and it will restart the address claim automatically.
```mermaid
---
title: NMEA2000_esp32xx Driver State Machine
---
stateDiagram-v2

    [*] --> STOPPED
    
    STOPPED --> RESTARTING: (autoRecoveryEnabled && timeout)<br/>twai_start()<br/>SendDummyFrame()
    STOPPED --> RUNNING: started by N2K stack
    
    RESTARTING --> RUNNING: tNMEA2000..Restart()
    RESTARTING --> STOPPED: (TxErr>0)<br/>reset timeout
    
    RUNNING --> RECOVERING: CAN bus error
    RUNNING --> STOPPED: (TxErr>=128)<br/>reset timeout
    
    RECOVERING --> STOPPED: (CAN bus recovered)<br/>reset timeout
```