### PR TITLE
clip length of var string to length of message

### DIFF
--- a/src/N2kMsg.cpp
+++ b/src/N2kMsg.cpp
@@ -435,6 +435,7 @@ bool tN2kMsg::GetVarStr(size_t &StrBufSize, char *StrBuf, int &Index) const {
   uint8_t Type=GetByte(Index);
   if ( Len<2) { StrBufSize=0; return false; } // invalid length
   Len-=2;
+  if ((Len+Index) > DataLen) Len=DataLen-Index; //seems to happen e.g. with 129041, canboat also does clipping this way
   if ( Type!=0x01 ) { StrBufSize=0; return false; }
   if ( StrBuf!=0 ) {
     GetStr(StrBufSize,StrBuf,Len,0xff,Index);


### PR DESCRIPTION
For my [converter project](https://github.com/wellenvogel/esp32-nmea2000) I received a couple of candumps that contain some slightly broken 129041 messages.
I was wondering why canboat was able to decode them but the NMEA200 library was not.
So I checked the code and saw that canboat clips the length of var strings to the length of the received message (whereas the NMEA2000 library currently drops the string completely when the message length is exceeded).
So this PR just adds the clipping of the string length to the received message length.