### PR TITLE
avoid an endless loop in ActisenseReader

### DIFF
--- a/src/ActisenseReader.cpp
+++ b/src/ActisenseReader.cpp
@@ -158,8 +158,7 @@ bool tActisenseReader::GetMessageFromStream(tN2kMsg &N2kMsg, bool ReadOut) {
               ReadStream->read(); // Read ch out
               ClearBuffer();
               StartOfTextReceived=true;
-            }
-            else{
+            } else {
               if (ReadOut) ReadStream->read();
             }
             break;

--- a/src/ActisenseReader.cpp
+++ b/src/ActisenseReader.cpp
@@ -159,6 +159,9 @@ bool tActisenseReader::GetMessageFromStream(tN2kMsg &N2kMsg, bool ReadOut) {
               ClearBuffer();
               StartOfTextReceived=true;
             }
+            else{
+              if (ReadOut) ReadStream->read();
+            }
             break;
           default:
             EscapeReceived=(NewByte==Escape);


### PR DESCRIPTION
Currently the ActisenseReader will go into an endless loop if it receives a StartOfData without an Escape before when waiting for a message.
At least with 'ReadOut' being set the value must be consumed.